### PR TITLE
Writer module overhauling

### DIFF
--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -6,7 +6,7 @@ extern crate avro;
 use avro::reader::Reader;
 use avro::schema::Schema;
 use avro::types::{Record, ToAvro, Value};
-use avro::writer::Writer;
+use avro::Writer;
 
 static RAW_SMALL_SCHEMA: &'static str = r#"
 {

--- a/benches/single.rs
+++ b/benches/single.rs
@@ -4,8 +4,8 @@ extern crate test;
 
 extern crate avro;
 use avro::schema::Schema;
+use avro::to_avro_datum;
 use avro::types::{Record, ToAvro, Value};
-use avro::writer::SingleWriter;
 
 static RAW_SMALL_SCHEMA: &'static str = r#"
 {
@@ -152,16 +152,9 @@ fn make_big_record() -> (Schema, Value) {
     (big_schema, big_record)
 }
 
-fn write(writer: &mut SingleWriter, record: Value) -> Vec<u8> {
-    let mut buffer = Vec::new();
-    writer.write(&mut buffer, record).unwrap();
-    buffer
-}
-
 fn bench_write(b: &mut test::Bencher, make_record: &Fn() -> (Schema, Value)) {
     let (schema, record) = make_record();
-    let mut writer = SingleWriter::new(&schema);
-    b.iter(|| write(&mut writer, record.clone()));
+    b.iter(|| to_avro_datum(&schema, record.clone()));
 }
 
 #[bench]

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use avro::reader::Reader;
 use avro::schema::Schema;
 use avro::types::{Record, ToAvro, Value};
-use avro::writer::Writer;
+use avro::Writer;
 
 fn nanos(duration: Duration) -> u64 {
     duration.as_secs() * 1_000_000_000 + duration.subsec_nanos() as u64

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,5 +1,4 @@
 //! Logic for all supported compression codecs in Avro.
-
 use std::io::{Read, Write};
 use std::str::FromStr;
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,6 +1,6 @@
 //! Logic for serde-compatible deserialization.
-use std::collections::HashMap;
 use std::collections::hash_map::{Keys, Values};
+use std::collections::HashMap;
 use std::error::{self, Error as StdError};
 use std::fmt;
 use std::slice::Iter;

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -47,7 +47,7 @@ pub fn encode(value: Value, buffer: &mut Vec<u8>) {
     }
 }
 
-pub fn encode_raw(value: Value) -> Vec<u8> {
+pub fn encode_to_vec(value: Value) -> Vec<u8> {
     let mut buffer = Vec::new();
     encode(value, &mut buffer);
     buffer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! use avro::reader::Reader;
 //! use avro::schema::Schema;
 //! use avro::types::Record;
-//! use avro::writer::Writer;
+//! use avro::Writer;
 //!
 //! #[derive(Debug, Deserialize, Serialize)]
 //! struct Test {
@@ -74,14 +74,15 @@ mod decode;
 mod encode;
 mod ser;
 mod util;
+mod writer;
 
 pub mod reader;
 pub mod schema;
 pub mod types;
-pub mod writer;
 
 pub use codec::Codec;
 pub use de::from_value;
+pub use writer::{to_avro_datum, Writer};
 
 #[cfg(test)]
 mod tests {
@@ -89,7 +90,6 @@ mod tests {
     use reader::Reader;
     use schema::Schema;
     use types::{Record, Value};
-    use writer::Writer;
 
     //TODO: move where it fits better
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,9 +64,15 @@ extern crate libflate;
 extern crate rand;
 #[macro_use]
 extern crate serde;
+
 extern crate serde_json;
 #[cfg(feature = "snappy")]
 extern crate snap;
+
+// test dependency
+#[cfg(test)]
+#[macro_use]
+extern crate serde_derive;
 
 mod codec;
 mod de;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,11 +70,11 @@ extern crate snap;
 
 mod codec;
 mod de;
+mod decode;
+mod encode;
 mod ser;
 mod util;
 
-pub mod decode;
-pub mod encode;
 pub mod reader;
 pub mod schema;
 pub mod types;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,15 +1,15 @@
 use std::collections::VecDeque;
 use std::io::{ErrorKind, Read};
 use std::rc::Rc;
-use std::str::{FromStr, from_utf8};
+use std::str::{from_utf8, FromStr};
 
 use failure::{err_msg, Error};
 use serde_json::from_slice;
 
-use Codec;
 use decode::decode;
 use schema::Schema;
 use types::Value;
+use Codec;
 
 pub struct Reader<'a, R> {
     reader: R,

--- a/src/types.rs
+++ b/src/types.rs
@@ -165,7 +165,7 @@ impl<S: Serialize> ToAvro for S {
 }
 */
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Record {
     pub rschema: Rc<RecordSchema>,
     pub fields: Vec<(String, Value)>,
@@ -378,7 +378,7 @@ impl Value {
         }
     }
 
-    pub fn resolve_enum(self, symbols: &Vec<String>) -> Result<Self, Error> {
+    fn resolve_enum(self, symbols: &Vec<String>) -> Result<Self, Error> {
         let validate_symbol = |symbol: String, symbols: &Vec<String>| {
             if let Some(index) = symbols.iter().position(|ref item| item == &&symbol) {
                 Ok(Value::Enum(index as i32, symbol))

--- a/src/types.rs
+++ b/src/types.rs
@@ -378,7 +378,7 @@ impl Value {
         }
     }
 
-    fn resolve_enum(self, symbols: &Vec<String>) -> Result<Self, Error> {
+    pub fn resolve_enum(self, symbols: &Vec<String>) -> Result<Self, Error> {
         let validate_symbol = |symbol: String, symbols: &Vec<String>| {
             if let Some(index) = symbols.iter().position(|ref item| item == &&symbol) {
                 Ok(Value::Enum(index as i32, symbol))

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -6,11 +6,11 @@ use rand::random;
 use serde::Serialize;
 use serde_json;
 
-use Codec;
-use encode::{encode, encode_raw};
+use encode::{encode, encode_to_vec};
 use schema::Schema;
 use ser::Serializer;
 use types::{ToAvro, Value};
+use Codec;
 
 pub const SYNC_SIZE: usize = 16;
 pub const SYNC_INTERVAL: usize = 1000 * SYNC_SIZE; // TODO: parametrize in Writer
@@ -92,7 +92,7 @@ impl<'a, W: Write> Writer<'a, W> {
     }
 
     fn append_raw(&mut self, value: Value) -> Result<usize, Error> {
-        self.append_bytes(encode_raw(value).as_ref())
+        self.append_bytes(encode_to_vec(value).as_ref())
     }
 
     fn append_bytes(&mut self, bytes: &[u8]) -> Result<usize, Error> {
@@ -188,8 +188,8 @@ impl<'a> SingleWriter<'a> {
         let num_bytes = self.buffer.len();
 
         writer.write_all(self.header.as_slice())?;
-        writer.write_all(encode_raw(1i64.avro()).as_ref())?;
-        writer.write_all(encode_raw(num_bytes.avro()).as_ref())?;
+        writer.write_all(encode_to_vec(1i64.avro()).as_ref())?;
+        writer.write_all(encode_to_vec(num_bytes.avro()).as_ref())?;
         writer.write_all(self.buffer.as_ref())?;
         writer.write_all(SINGLE_WRITER_MARKER)?;
 


### PR DESCRIPTION
This PR is proposing some changes to the writer module (and partially to the whole crate) as per the following commit messages.

```
Make encode and decode private

There is little reason why these should be public, especially if we
expose a write function with very little overhead.

They can always be made public when needed.
```

---

```
Substitute SingleWriter with to_avro_datum

The avro implementations in other languages provide a DataFileWriter and
a DatumWriter which are respectively the interface to write to a file
with buffering and headers and the interface to just convert a value to
avro.

While Writer is definitely equivalent (actually more generic than
DataFileWriter since it accepts anything implementing Write), the
SingleWriter struct wasn't really similar to DatumWriter. For this
reason we replaced SingleWriter with the function to_avro_datum which
does exactly what DatumWriter does.

Please notice that the Rust package doesn't provide a public
Encoder/Decoder interface like other implementations at the moment,
since we only support binary encoding. Given that we don't even pass the
writable interface down to the encoder (because we can't see why we
should do it), this makes the Encoder/Decoder pretty much useless for
the users of the library.

This commit also changes the visibility rules of the writer module,
re-exporting Writer and to_avro_datum at the lib level.
```

---

```
Documentation for writer module
```

---

```
Add unit tests to writer module

The number of bytes returned by the writing operations didn't add up
with the length of the output data. Fixed two bugs causing that.
```

---

```
Implement Writer::extend_ser for parity with extend  …
Until we are not able to make Value implement Serialize, we are obliged
to duplicate the interface for the writer.
```

Close #17  
Close #9 
Reference #12 