### PR TITLE
Reader module tests, documentation and interface overhaul

### DIFF
--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -3,9 +3,9 @@
 extern crate test;
 
 extern crate avro;
-use avro::reader::Reader;
 use avro::schema::Schema;
 use avro::types::{Record, ToAvro, Value};
+use avro::Reader;
 use avro::Writer;
 
 static RAW_SMALL_SCHEMA: &'static str = r#"

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -3,9 +3,9 @@ extern crate avro;
 use std::time::Duration;
 use std::time::Instant;
 
-use avro::reader::Reader;
 use avro::schema::Schema;
 use avro::types::{Record, ToAvro, Value};
+use avro::Reader;
 use avro::Writer;
 
 fn nanos(duration: Duration) -> u64 {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -8,6 +8,7 @@ use schema::Schema;
 use types::Value;
 use util::{zag_i32, zag_i64};
 
+/// Decode a `Value` from avro format given its `Schema`.
 pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> {
     match schema {
         &Schema::Null => Ok(Value::Null),

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -3,6 +3,7 @@ use std::mem::transmute;
 use types::{ToAvro, Value};
 use util::{zig_i32, zig_i64};
 
+/// Encode a `Value` into avro format.
 pub fn encode(value: Value, buffer: &mut Vec<u8>) {
     match value {
         Value::Null => (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! use avro::Codec;
 //! use avro::from_value;
-//! use avro::reader::Reader;
+//! use avro::Reader;
 //! use avro::schema::Schema;
 //! use avro::types::Record;
 //! use avro::Writer;
@@ -78,16 +78,17 @@ mod codec;
 mod de;
 mod decode;
 mod encode;
+mod reader;
 mod ser;
 mod util;
 mod writer;
 
-pub mod reader;
 pub mod schema;
 pub mod types;
 
 pub use codec::Codec;
 pub use de::from_value;
+pub use reader::Reader;
 pub use writer::{to_avro_datum, Writer};
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //!     writer.flush().unwrap();
 //!
 //!     let input = writer.into_inner();
-//!     let reader = Reader::with_schema(&schema, &input[..]);
+//!     let reader = Reader::with_schema(&schema, &input[..]).unwrap();
 //!
 //!     for record in reader {
 //!         println!("{:?}", from_value::<Test>(&record.unwrap()));
@@ -139,7 +139,7 @@ mod tests {
         writer.append(record).unwrap();
         writer.flush().unwrap();
         let input = writer.into_inner();
-        let mut reader = Reader::with_schema(&reader_schema, &input[..]);
+        let mut reader = Reader::with_schema(&reader_schema, &input[..]).unwrap();
         assert_eq!(
             reader.next().unwrap().unwrap(),
             Value::Record(vec![
@@ -182,7 +182,7 @@ mod tests {
         writer.append(record).unwrap();
         writer.flush().unwrap();
         let input = writer.into_inner();
-        let mut reader = Reader::with_schema(&schema, &input[..]);
+        let mut reader = Reader::with_schema(&schema, &input[..]).unwrap();
         assert_eq!(
             reader.next().unwrap().unwrap(),
             Value::Record(vec![
@@ -245,7 +245,7 @@ mod tests {
         writer.append(record).unwrap();
         writer.flush().unwrap();
         let input = writer.into_inner();
-        let mut reader = Reader::with_schema(&reader_schema, &input[..]);
+        let mut reader = Reader::with_schema(&reader_schema, &input[..]).unwrap();
         assert!(reader.next().unwrap().is_err());
         assert!(reader.next().is_none());
     }
@@ -281,7 +281,7 @@ mod tests {
         writer.append(record).unwrap();
         writer.flush().unwrap();
         let input = writer.into_inner();
-        let mut reader = Reader::new(&input[..]);
+        let mut reader = Reader::new(&input[..]).unwrap();
         assert_eq!(
             reader.next().unwrap().unwrap(),
             Value::Record(vec![

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -17,7 +17,7 @@ use Codec;
 /// To be used as in iterator:
 ///
 /// ```no_run
-/// # use avro::reader::Reader;
+/// # use avro::Reader;
 /// # use std::io::Cursor;
 /// # let input = Cursor::new(Vec::<u8>::new());
 /// for value in Reader::new(input) {


### PR DESCRIPTION
```
Add documentation for reader module
```
---
```
Re-export Reader in lib.rs
```
---
```
Add tests for Reader and read header at creation

Implementing a lazy reading of the header causes a couple problems in
the implementation (e.g. infinite loops without a couple state flags)
and the writer schema to be an Option until the first value is read
or read_header is called. For this reason, header is read at creation
time and now both new and with_codec do return a Result.

Writing tests, a second bug that could cause many errors to be returned
by the iterator instead of only one emerged. To fix it, a flag to signal
that the reader entered in a state of error has been added, so the
iteration will stop automatically at the next step.
```
---
```
Add from_avro_datum function and more tests for reader

from_avro_datum has been added for parity with to_avro_datum
```

Close #10 
Reference #12