### PR TITLE
Schema documentation and unit tests.

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -121,8 +121,7 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
                 _ => Err(err_msg("union index out of bounds")),
             }
         },
-        &Schema::Record(ref rschema) => rschema
-            .fields
+        &Schema::Record { ref fields, .. } => fields
             .iter()
             .map(|field| decode(&field.schema, reader).map(|value| (field.name.clone(), value)))
             .collect::<Result<Vec<(String, Value)>, _>>()

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,3 +1,4 @@
+//! Logic for parsing and interacting with schemas in Avro format.
 use std::collections::HashMap;
 use std::rc::Rc;
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -271,6 +271,8 @@ impl Schema {
         }
     }
 
+    /// Parse a `serde_json::Value` representing a Avro record type into a
+    /// `Schema`.
     fn parse_record(complex: &Map<String, Value>) -> Result<Self, Error> {
         let name = Name::parse(complex)?;
 
@@ -301,6 +303,8 @@ impl Schema {
         })
     }
 
+    /// Parse a `serde_json::Value` representing a Avro enum type into a
+    /// `Schema`.
     fn parse_enum(complex: &Map<String, Value>) -> Result<Self, Error> {
         let name = Name::parse(complex)?;
 
@@ -323,6 +327,8 @@ impl Schema {
         })
     }
 
+    /// Parse a `serde_json::Value` representing a Avro array type into a
+    /// `Schema`.
     fn parse_array(complex: &Map<String, Value>) -> Result<Self, Error> {
         complex
             .get("items")
@@ -331,6 +337,8 @@ impl Schema {
             .map(|schema| Schema::Array(Rc::new(schema)))
     }
 
+    /// Parse a `serde_json::Value` representing a Avro map type into a
+    /// `Schema`.
     fn parse_map(complex: &Map<String, Value>) -> Result<Self, Error> {
         complex
             .get("values")
@@ -339,6 +347,8 @@ impl Schema {
             .map(|schema| Schema::Map(Rc::new(schema)))
     }
 
+    /// Parse a `serde_json::Value` representing a Avro union type into a
+    /// `Schema`.
     fn parse_union(items: &Vec<Value>) -> Result<Self, Error> {
         /*
         items.iter()
@@ -364,6 +374,8 @@ impl Schema {
         */
     }
 
+    /// Parse a `serde_json::Value` representing a Avro fixed type into a
+    /// `Schema`.
     fn parse_fixed(complex: &Map<String, Value>) -> Result<Self, Error> {
         let name = Name::parse(complex)?;
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -54,7 +54,10 @@ pub enum Schema {
         name: Name,
         doc: Documentation,
         fields: Vec<RecordField>,
-        lookup: HashMap<String, usize>,
+
+        // TODO: this does not look great.
+        // This is just a trick to avoid borrows of Schema into types::Record.
+        lookup: Rc<HashMap<String, usize>>,
     },
     /// An `enum` Avro schema.
     Enum {
@@ -293,7 +296,7 @@ impl Schema {
             name,
             doc: complex.doc(),
             fields,
-            lookup,
+            lookup: Rc::new(lookup),
         })
     }
 
@@ -538,7 +541,7 @@ mod tests {
                     position: 1,
                 },
             ],
-            lookup,
+            lookup: Rc::new(lookup),
         };
 
         assert_eq!(expected, schema);

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,4 @@
+//! Logic handling the intermediate representation of Avro values.
 use std::collections::HashMap;
 use std::rc::Rc;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -165,13 +165,20 @@ impl<S: Serialize> ToAvro for S {
 }
 */
 
+/// Utility interface to build `Value::Record` objects.
 #[derive(Debug, Clone)]
 pub struct Record {
+    /// List of fields contained in the record.
+    /// Ordered according to the fields in the schema given to create this
+    /// `Record` object. Any unset field defaults to `Value::Null`.
     pub fields: Vec<(String, Value)>,
     schema_lookup: Rc<HashMap<String, usize>>,
 }
 
 impl Record {
+    /// Create a `Record` given a `Schema`.
+    ///
+    /// If the `Schema` is not a `Schema::Record` variant, `None` will be returned.
     pub fn new(schema: &Schema) -> Option<Record> {
         match schema {
             &Schema::Record {
@@ -193,6 +200,11 @@ impl Record {
         }
     }
 
+    /// Put a compatible value (implementing the `ToAvro` trait) in the
+    /// `Record` for a given `field` name.
+    ///
+    /// **NOTE** Only ensure that the field name is present in the `Schema` given when creating
+    /// this `Record`. Does not perform any schema validation.
     pub fn put<V>(&mut self, field: &str, value: V)
     where
         V: ToAvro,


### PR DESCRIPTION
Also features a small refactor of `Schema::Record`
Closes #8 

(This PR ended being quite long, sorry and thanks in advance 🙈 )

---

```
Remove RecordSchema struct

This makes `Schema::Record` more in line with the other `Schema::`
variants (`Enum` and `Fixed`).

Also makes creation of `Schema::Record` easier (less `Rc`, one less
struct) and allows to use only specific items (e.g: `fields`).
```

---

```
Add documentation and tests to Schema
```

---

```
Avoid borrowing Schema in types::Record
```

---

```
Add documentation for Record
```

---

```
Add module-level documentation for schema.rs and types.rs
```

---

```
Add docstrings for parse_*
```