### PR TITLE
Avoid calling .resolve when writing datum

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,10 +1,15 @@
 use std::mem::transmute;
 
+use schema::Schema;
 use types::{ToAvro, Value};
 use util::{zig_i32, zig_i64};
 
 /// Encode a `Value` into avro format.
-pub fn encode(value: Value, buffer: &mut Vec<u8>) {
+///
+/// **NOTE** This will not perform schema validation. The value is assumed to
+/// be valid with regards to the schema. Schema are needed only to guide the
+/// encoding for complex type values.
+pub fn encode(value: Value, schema: &Schema, buffer: &mut Vec<u8>) {
     match value {
         Value::Null => (),
         Value::Boolean(b) => buffer.push(if b { 1u8 } else { 0u8 }),
@@ -13,43 +18,65 @@ pub fn encode(value: Value, buffer: &mut Vec<u8>) {
         Value::Float(x) => buffer.extend(unsafe { transmute::<f32, [u8; 4]>(x) }.to_vec()),
         Value::Double(x) => buffer.extend(unsafe { transmute::<f64, [u8; 8]>(x) }.to_vec()),
         Value::Bytes(bytes) => {
-            encode(Value::Long(bytes.len() as i64), buffer);
+            encode(Value::Long(bytes.len() as i64), &Schema::Long, buffer);
             buffer.extend(bytes);
         },
-        Value::String(s) => {
-            encode(Value::Long(s.len() as i64), buffer);
-            buffer.extend(s.into_bytes());
+        Value::String(s) => match schema {
+            &Schema::String => {
+                encode(Value::Long(s.len() as i64), &Schema::Long, buffer);
+                buffer.extend(s.into_bytes());
+            },
+            &Schema::Enum { ref symbols, .. } => {
+                if let Some(index) = symbols.iter().position(|ref item| item == &&s) {
+                    encode(Value::Enum(index as i32, s), schema, buffer);
+                }
+            },
+            _ => (),
         },
         Value::Fixed(_, bytes) => buffer.extend(bytes),
-        Value::Enum(i, _) => encode(Value::Int(i), buffer),
+        Value::Enum(i, _) => encode(Value::Int(i), &Schema::Int, buffer),
         Value::Union(None) => buffer.push(0u8),
         Value::Union(Some(item)) => {
-            buffer.push(1u8);
-            encode(*item, buffer);
+            if let &Schema::Union(ref inner) = schema {
+                buffer.push(1u8);
+                encode(*item, inner, buffer);
+            }
         },
         Value::Array(items) => {
-            encode(items.len().avro(), buffer);
-            for item in items.into_iter() {
-                encode(item, buffer);
+            if let &Schema::Array(ref inner) = schema {
+                encode(items.len().avro(), &Schema::Long, buffer);
+                for item in items.into_iter() {
+                    encode(item, inner, buffer);
+                }
+                buffer.push(0u8);
             }
-            buffer.push(0u8);
         },
         Value::Map(items) => {
-            encode(items.len().avro(), buffer);
-            for (key, value) in items.into_iter() {
-                encode(Value::String(key), buffer);
-                encode(value, buffer);
+            if let &Schema::Map(ref inner) = schema {
+                encode(items.len().avro(), &Schema::Long, buffer);
+                for (key, value) in items.into_iter() {
+                    encode(Value::String(key), &Schema::String, buffer);
+                    encode(value, inner, buffer);
+                }
+                buffer.push(0u8);
             }
-            buffer.push(0u8);
         },
-        Value::Record(fields) => for (_, value) in fields.into_iter() {
-            encode(value, buffer);
+        Value::Record(fields) => {
+            if let &Schema::Record {
+                fields: ref schema_fields,
+                ..
+            } = schema
+            {
+                for (i, (_, value)) in fields.into_iter().enumerate() {
+                    encode(value, &schema_fields[i].schema, buffer);
+                }
+            }
         },
     }
 }
 
-pub fn encode_to_vec(value: Value) -> Vec<u8> {
+pub fn encode_to_vec(value: Value, schema: &Schema) -> Vec<u8> {
     let mut buffer = Vec::new();
-    encode(value, &mut buffer);
+    encode(value, schema, &mut buffer);
     buffer
 }


### PR DESCRIPTION
I had to make `encode` take a Schema as parameter to help "guide" the encoding. Quite unhappy about it, but that's the least-worst I could come up with.

Adding a `Schema` to `ToAvro` would have added too much overhead for complex types (having to rebuild an array, map or record everytime `.avro()` is called).