### PR TITLE
Various fixes/improvements to the documentation

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -385,6 +385,10 @@ impl<'de> de::Deserializer<'de> for StringDeserializer {
     }
 }
 
+/// Interpret a `Value` as an instance of type `D`.
+///
+/// This conversion can fail if the structure of the `Value` does not match the
+/// structure expected by `D`.
 pub fn from_value<'de, D: Deserialize<'de>>(value: &'de Value) -> Result<D, Error> {
     let mut de = Deserializer::new(value);
     D::deserialize(&mut de)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -520,9 +520,9 @@ pub mod types;
 
 pub use codec::Codec;
 pub use de::from_value;
-pub use reader::Reader;
-pub use writer::{to_avro_datum, Writer};
+pub use reader::{from_avro_datum, Reader};
 pub use schema::Schema;
+pub use writer::{to_avro_datum, Writer};
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,7 @@
 //! Avro supports three different compression codecs when encoding data:
 //!
 //! * **Null**: leaves data uncompressed;
-//! * **Deflate: writes the data block using the deflate algorithm as specified in RFC 1951, and
+//! * **Deflate**: writes the data block using the deflate algorithm as specified in RFC 1951, and
 //! typically implemented using the zlib library. Note that this format (unlike the "zlib format" in
 //! RFC 1950) does not have a checksum.
 //! * **Snappy**: uses Google's [Snappy](http://google.github.io/snappy/) compression library. Each

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -112,9 +112,8 @@ impl<'a, W: Write> Writer<'a, W> {
     ///
     /// Return the number of bytes written.
     ///
-    /// **NOTE** This function is not guaranteed to perform any actual write, since it relies on
-    /// internal buffering for performance reasons. If you want to be sure the value has been
-    /// written, then call [`flush`](struct.Writer.html#method.flush).
+    /// **NOTE** This function forces the written data to be flushed (an implicit
+    /// call to [`flush`](struct.Writer.html#method.flush) is performed).
     pub fn extend<I, T: ToAvro>(&mut self, values: I) -> Result<usize, Error>
     where
         I: Iterator<Item = T>,
@@ -148,9 +147,8 @@ impl<'a, W: Write> Writer<'a, W> {
     ///
     /// Return the number of bytes written.
     ///
-    /// **NOTE** This function is not guaranteed to perform any actual write, since it relies on
-    /// internal buffering for performance reasons. If you want to be sure the value has been
-    /// written, then call [`flush`](struct.Writer.html#method.flush).
+    /// **NOTE** This function forces the written data to be flushed (an implicit
+    /// call to [`flush`](struct.Writer.html#method.flush) is performed).
     pub fn extend_ser<I, T: Serialize>(&mut self, values: I) -> Result<usize, Error>
     where
         I: Iterator<Item = T>,


### PR DESCRIPTION
Fixes #25 

    Add missing asterisks in documentation.

---

    Fix Writer::extend documentation.

    Writer::extend makes an internal call to `flush`. Even if we rely on
    the internal buffering while appending each of the values from the
    iterator, data is actually written to the inner `io::Write` interface in
    the end. Made this explicit.

---

    Make from_avro_datum publicly available.

    Because to_avro_datum is public, and it makes sense to have this
    one public as well, in case anyone needs it.

---

    Add documentation for from_value.

    Documentation was missing for this "key" function. Took the liberty
    to re-use the words from serde_json as the wording is nice 🙂

(https://docs.serde.rs/serde_json/fn.from_value.html)
