### PR TITLE
Move from string as errors to custom fail types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ snappy = ["snap"]
 
 [dependencies]
 failure = "0.1.1"
+failure_derive = "0.1.1"
 libflate = "0.1"
 rand = "0.3"
 serde = "1.0"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -8,6 +8,7 @@ use libflate::deflate::{Decoder, Encoder};
 use snap::{Reader, Writer};
 
 use types::{ToAvro, Value};
+use util::DecodeError;
 
 /// The compression codec used to compress blocks.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -40,7 +41,7 @@ impl ToAvro for Codec {
 }
 
 impl FromStr for Codec {
-    type Err = ();
+    type Err = DecodeError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
@@ -48,7 +49,7 @@ impl FromStr for Codec {
             "deflate" => Ok(Codec::Deflate),
             #[cfg(feature = "snappy")]
             "snappy" => Ok(Codec::Snappy),
-            _ => Err(()),
+            _ => Err(DecodeError::new("unrecognized codec")),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -492,6 +492,8 @@
 //! ```
 
 extern crate failure;
+#[macro_use]
+extern crate failure_derive;
 extern crate libflate;
 extern crate rand;
 #[macro_use]
@@ -521,8 +523,10 @@ pub mod types;
 pub use codec::Codec;
 pub use de::from_value;
 pub use reader::{from_avro_datum, Reader};
-pub use schema::Schema;
-pub use writer::{to_avro_datum, Writer};
+pub use schema::{ParseSchemaError, Schema};
+pub use types::SchemaResolutionError;
+pub use util::DecodeError;
+pub use writer::{to_avro_datum, ValidationError, Writer};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
This change moves the crate from using strings as errors, which is a
pattern that should be used only for prototyping, to defining custom
fail types, based on https://boats.gitlab.io/failure/

I have decided to define four different error structs based on what is
written in this GitHub issue:
https://github.com/rust-lang-nursery/failure/issues/7

However, I am very open to change everything to a single error type
defined as an enum, if you prefer so.

In addition, this branch also resurrects a simple zigzag test that
slipped through our test revamp as commented.