### PR TITLE
Encodes/decodes union values with a leading zig-zag long.

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -112,12 +112,11 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
             Ok(Value::Map(items))
         },
         &Schema::Union(ref inner) => {
-            let mut buf = [0u8; 1];
-            reader.read_exact(&mut buf)?;
+            let index = zag_i64(reader)?;
 
-            match buf[0] {
-                0u8 => Ok(Value::Union(None)),
-                1u8 => decode(inner, reader),
+            match index {
+                0 => Ok(Value::Union(None)),
+                1 => decode(inner, reader).map(|x| Value::Union(Some(Box::new(x)))),
                 _ => Err(DecodeError::new("union index out of bounds").into()),
             }
         },

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -38,7 +38,7 @@ pub fn encode(value: Value, schema: &Schema, buffer: &mut Vec<u8>) {
         Value::Union(None) => buffer.push(0u8),
         Value::Union(Some(item)) => {
             if let &Schema::Union(ref inner) = schema {
-                buffer.push(1u8);
+                encode(Value::Long(1), &Schema::Long, buffer);
                 encode(*item, inner, buffer);
             }
         },

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -242,6 +242,9 @@ mod tests {
                 ]
             }
         "#;
+    static UNION_SCHEMA: &'static str = r#"
+            ["null", "long"]
+        "#;
     static ENCODED: &'static [u8] = &[
         79u8, 98u8, 106u8, 1u8, 4u8, 22u8, 97u8, 118u8, 114u8, 111u8, 46u8, 115u8, 99u8, 104u8,
         101u8, 109u8, 97u8, 222u8, 1u8, 123u8, 34u8, 116u8, 121u8, 112u8, 101u8, 34u8, 58u8, 34u8,
@@ -274,6 +277,18 @@ mod tests {
             expected
         );
     }
+
+    #[test]
+    fn test_union() {
+        let schema = Schema::parse_str(UNION_SCHEMA).unwrap();
+        let mut encoded: &'static [u8] = &[2,0];
+
+        assert_eq!(
+            from_avro_datum(&schema, &mut encoded, None).unwrap(),
+            Value::Union(Some(Box::new(Value::Long(0))))
+        );
+    }
+
 
     #[test]
     fn test_reader_iterator() {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -306,6 +306,9 @@ mod tests {
                 ]
             }
         "#;
+    static UNION_SCHEMA: &'static str = r#"
+            ["null", "long"]
+        "#;
 
     #[test]
     fn test_to_avro_datum() {
@@ -321,6 +324,19 @@ mod tests {
 
         assert_eq!(to_avro_datum(&schema, record).unwrap(), expected);
     }
+
+    #[test]
+    fn test_union() {
+        let schema = Schema::parse_str(UNION_SCHEMA).unwrap();
+        let union = Value::Union(Some(Box::new(Value::Long(3))));
+
+        let mut expected = Vec::new();
+        zig_i64(1, &mut expected);
+        zig_i64(3, &mut expected);
+
+        assert_eq!(to_avro_datum(&schema, union).unwrap(), expected);   
+    }
+
 
     #[test]
     fn test_writer_append() {


### PR DESCRIPTION
Previously the index at the beginning of an union value
had been a directly-encoded byte.  Also fixes a problem where
the value was not correctly wrapped in a Value::Union upon decode.

Also, tests for all new code.

Fixes #33.