### PR TITLE
Add a maximum allocation size when decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,39 @@ fn main() -> Result<(), Error> {
 }
 ```
 
+### Ill-formed data
+
+In order to ease decoding, the Binary Encoding specification of Avro data
+requires some fields to have their length encoded alongside the data.
+
+If encoded data passed to a `Reader` has been ill-formed, it can happen that
+the bytes meant to contain the length of data are bogus and could result
+in extravagant memory allocation.
+
+To shield users from ill-formed data, `avro-rs` sets a limit (default: 512MB)
+to any allocation it will perform when decoding data.
+
+If you expect some of your data fields to be larger than this limit, be sure
+to make use of the `max_allocation_bytes` function before reading **any** data
+(we leverage Rust's [`std::sync::Once`](https://doc.rust-lang.org/std/sync/struct.Once.html) mechanism to initialize this value, if
+any call to decode is made before a call to `max_allocation_bytes`, the limit
+will be 512MB throughout the lifetime of the program).
+
+
+```rust
+extern crate avro_rs;
+
+use avro_rs::max_allocation_bytes;
+
+
+fn main() {
+    max_allocation_bytes(2 * 1024 * 1024 * 1024);  // 2GB
+
+    // ... happily decode large data
+}
+
+```
+
 ## License
 This project is licensed under [MIT License](https://github.com/flavray/avro-rs/blob/master/LICENSE).
 Please note that this is not an official project maintained by [Apache Avro](https://avro.apache.org/).

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -54,7 +54,7 @@ fn benchmark(schema: &Schema, record: &Value, s: &str, count: usize, runs: usize
 
     for _ in 0..runs {
         let start = Instant::now();
-        let reader = Reader::with_schema(schema, &bytes[..]);
+        let reader = Reader::with_schema(schema, &bytes[..]).unwrap();
 
         let mut read_records = Vec::with_capacity(count);
         for record in reader {
@@ -64,7 +64,7 @@ fn benchmark(schema: &Schema, record: &Value, s: &str, count: usize, runs: usize
         let duration = Instant::now().duration_since(start);
         durations.push(duration);
 
-        // assert_eq!(count, read_records.len());
+        assert_eq!(count, read_records.len());
     }
 
     let total_duration_read = durations.into_iter().fold(0u64, |a, b| a + nanos(b));

--- a/src/de.rs
+++ b/src/de.rs
@@ -316,11 +316,9 @@ impl<'de> de::MapAccess<'de> for MapDeserializer<'de> {
         K: DeserializeSeed<'de>,
     {
         match self.input_keys.next() {
-            Some(ref key) => {
-                seed.deserialize(StringDeserializer {
-                    input: (*key).clone(),
-                }).map(Some)
-            },
+            Some(ref key) => seed.deserialize(StringDeserializer {
+                input: (*key).clone(),
+            }).map(Some),
             None => Ok(None),
         }
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -6,7 +6,7 @@ use failure::Error;
 
 use schema::Schema;
 use types::Value;
-use util::{zag_i32, zag_i64, DecodeError};
+use util::{safe_len, zag_i32, zag_i64, DecodeError};
 
 #[inline]
 fn decode_long<R: Read>(reader: &mut R) -> Result<Value, Error> {
@@ -16,6 +16,11 @@ fn decode_long<R: Read>(reader: &mut R) -> Result<Value, Error> {
 #[inline]
 fn decode_int<R: Read>(reader: &mut R) -> Result<Value, Error> {
     zag_i32(reader).map(Value::Int)
+}
+
+#[inline]
+fn decode_len<R: Read>(reader: &mut R) -> Result<usize, Error> {
+    zag_i64(reader).and_then(|len| safe_len(len as usize))
 }
 
 /// Decode a `Value` from avro format given its `Schema`.
@@ -45,33 +50,25 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
             Ok(Value::Double(unsafe { transmute::<[u8; 8], f64>(buf) }))
         },
         Schema::Bytes => {
-            if let Value::Long(len) = decode_long(reader)? {
-                let len = len as usize;
-                let mut buf = Vec::with_capacity(len);
-                unsafe {
-                    buf.set_len(len);
-                }
-                reader.read_exact(&mut buf)?;
-                Ok(Value::Bytes(buf))
-            } else {
-                Err(DecodeError::new("bytes len not found").into())
+            let len = decode_len(reader)?;
+            let mut buf = Vec::with_capacity(len);
+            unsafe {
+                buf.set_len(len);
             }
+            reader.read_exact(&mut buf)?;
+            Ok(Value::Bytes(buf))
         },
         Schema::String => {
-            if let Value::Long(len) = decode_long(reader)? {
-                let len = len as usize;
-                let mut buf = Vec::with_capacity(len);
-                unsafe {
-                    buf.set_len(len);
-                }
-                reader.read_exact(&mut buf)?;
-
-                String::from_utf8(buf)
-                    .map(Value::String)
-                    .map_err(|_| DecodeError::new("not a valid utf-8 string").into())
-            } else {
-                Err(DecodeError::new("string len not found").into())
+            let len = decode_len(reader)?;
+            let mut buf = Vec::with_capacity(len);
+            unsafe {
+                buf.set_len(len);
             }
+            reader.read_exact(&mut buf)?;
+
+            String::from_utf8(buf)
+                .map(Value::String)
+                .map_err(|_| DecodeError::new("not a valid utf-8 string").into())
         },
         Schema::Fixed { size, .. } => {
             let mut buf = vec![0u8; size as usize];
@@ -82,19 +79,16 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
             let mut items = Vec::new();
 
             loop {
-                if let Value::Long(len) = decode_long(reader)? {
-                    // arrays are 0-terminated, 0i64 is also encoded as 0 in Avro
-                    // reading a length of 0 means the end of the array
-                    if len == 0 {
-                        break
-                    }
+                let len = decode_len(reader)?;
+                // arrays are 0-terminated, 0i64 is also encoded as 0 in Avro
+                // reading a length of 0 means the end of the array
+                if len == 0 {
+                    break
+                }
 
-                    items.reserve(len as usize);
-                    for _ in 0..len {
-                        items.push(decode(inner, reader)?);
-                    }
-                } else {
-                    return Err(DecodeError::new("array len not found").into())
+                items.reserve(len as usize);
+                for _ in 0..len {
+                    items.push(decode(inner, reader)?);
                 }
             }
 
@@ -104,24 +98,21 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
             let mut items = HashMap::new();
 
             loop {
-                if let Value::Long(len) = decode_long(reader)? {
-                    // maps are 0-terminated, 0i64 is also encoded as 0 in Avro
-                    // reading a length of 0 means the end of the map
-                    if len == 0 {
-                        break
-                    }
+                let len = decode_len(reader)?;
+                // maps are 0-terminated, 0i64 is also encoded as 0 in Avro
+                // reading a length of 0 means the end of the map
+                if len == 0 {
+                    break
+                }
 
-                    items.reserve(len as usize);
-                    for _ in 0..len {
-                        if let Value::String(key) = decode(&Schema::String, reader)? {
-                            let value = decode(inner, reader)?;
-                            items.insert(key, value);
-                        } else {
-                            return Err(DecodeError::new("map key is not a string").into())
-                        }
+                items.reserve(len as usize);
+                for _ in 0..len {
+                    if let Value::String(key) = decode(&Schema::String, reader)? {
+                        let value = decode(inner, reader)?;
+                        items.insert(key, value);
+                    } else {
+                        return Err(DecodeError::new("map key is not a string").into())
                     }
-                } else {
-                    return Err(DecodeError::new("map len not found").into())
                 }
             }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -57,8 +57,7 @@ impl<R: Read> Block<R> {
 
         if let Value::Map(meta) = decode(&meta_schema, &mut self.reader)? {
             // TODO: surface original parse schema errors instead of coalescing them here
-            let schema = meta
-                .get("avro.schema")
+            let schema = meta.get("avro.schema")
                 .and_then(|bytes| {
                     if let Value::Bytes(ref bytes) = *bytes {
                         from_slice(bytes.as_ref()).ok()
@@ -73,8 +72,7 @@ impl<R: Read> Block<R> {
                 return Err(ParseSchemaError::new("unable to parse schema").into())
             }
 
-            if let Some(codec) = meta
-                .get("avro.codec")
+            if let Some(codec) = meta.get("avro.codec")
                 .and_then(|codec| {
                     if let Value::Bytes(ref bytes) = *codec {
                         from_utf8(bytes.as_ref()).ok()

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -149,8 +149,7 @@ impl Name {
         if self.name.contains('.') {
             self.name.clone()
         } else {
-            let namespace = self
-                .namespace
+            let namespace = self.namespace
                 .as_ref()
                 .map(|s| s.as_ref())
                 .or(default_namespace);

--- a/src/types.rs
+++ b/src/types.rs
@@ -457,12 +457,10 @@ impl Value {
 
     fn resolve_array(self, schema: &Schema) -> Result<Self, Error> {
         match self {
-            Value::Array(items) => Ok(Value::Array(
-                items
-                    .into_iter()
-                    .map(|item| item.resolve(schema))
-                    .collect::<Result<Vec<_>, _>>()?,
-            )),
+            Value::Array(items) => Ok(Value::Array(items
+                .into_iter()
+                .map(|item| item.resolve(schema))
+                .collect::<Result<Vec<_>, _>>()?)),
             other => Err(SchemaResolutionError::new(format!(
                 "Array({:?}) expected, got {:?}",
                 schema, other
@@ -472,12 +470,10 @@ impl Value {
 
     fn resolve_map(self, schema: &Schema) -> Result<Self, Error> {
         match self {
-            Value::Map(items) => Ok(Value::Map(
-                items
-                    .into_iter()
-                    .map(|(key, value)| value.resolve(schema).map(|value| (key, value)))
-                    .collect::<Result<HashMap<_, _>, _>>()?,
-            )),
+            Value::Map(items) => Ok(Value::Map(items
+                .into_iter()
+                .map(|(key, value)| value.resolve(schema).map(|value| (key, value)))
+                .collect::<Result<HashMap<_, _>, _>>()?)),
             other => Err(SchemaResolutionError::new(format!(
                 "Map({:?}) expected, got {:?}",
                 schema, other
@@ -655,33 +651,25 @@ mod tests {
             ]).validate(&schema)
         );
 
-        assert!(
-            !Value::Record(vec![
-                ("b".to_string(), Value::String("foo".to_string())),
-                ("a".to_string(), Value::Long(42i64)),
-            ]).validate(&schema)
-        );
+        assert!(!Value::Record(vec![
+            ("b".to_string(), Value::String("foo".to_string())),
+            ("a".to_string(), Value::Long(42i64)),
+        ]).validate(&schema));
 
-        assert!(
-            !Value::Record(vec![
-                ("a".to_string(), Value::Boolean(false)),
-                ("b".to_string(), Value::String("foo".to_string())),
-            ]).validate(&schema)
-        );
+        assert!(!Value::Record(vec![
+            ("a".to_string(), Value::Boolean(false)),
+            ("b".to_string(), Value::String("foo".to_string())),
+        ]).validate(&schema));
 
-        assert!(
-            !Value::Record(vec![
-                ("a".to_string(), Value::Long(42i64)),
-                ("c".to_string(), Value::String("foo".to_string())),
-            ]).validate(&schema)
-        );
+        assert!(!Value::Record(vec![
+            ("a".to_string(), Value::Long(42i64)),
+            ("c".to_string(), Value::String("foo".to_string())),
+        ]).validate(&schema));
 
-        assert!(
-            !Value::Record(vec![
-                ("a".to_string(), Value::Long(42i64)),
-                ("b".to_string(), Value::String("foo".to_string())),
-                ("c".to_string(), Value::Null),
-            ]).validate(&schema)
-        );
+        assert!(!Value::Record(vec![
+            ("a".to_string(), Value::Long(42i64)),
+            ("b".to_string(), Value::String("foo".to_string())),
+            ("c".to_string(), Value::Null),
+        ]).validate(&schema));
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,29 @@
 use std::io::Read;
+use std::sync::{Once, ONCE_INIT};
 
 use failure::Error;
 use serde_json::{Map, Value};
+
+/// Maximum number of bytes that can be allocated when decoding
+/// Avro-encoded values. This is a protection against ill-formed
+/// data, whose length field might be interpreted as enourmous.
+/// See max_allocation_bytes to change this limit.
+pub static mut MAX_ALLOCATION_BYTES: usize = 512 * 1024 * 1024;
+static MAX_ALLOCATION_BYTES_ONCE: Once = ONCE_INIT;
+
+/// Describes errors happened trying to allocate too many bytes
+#[derive(Fail, Debug)]
+#[fail(display = "Allocation error: {}", _0)]
+pub struct AllocationError(String);
+
+impl AllocationError {
+    pub fn new<S>(msg: S) -> AllocationError
+    where
+        S: Into<String>,
+    {
+        AllocationError(msg.into())
+    }
+}
 
 /// Describes errors happened while decoding Avro data.
 #[derive(Fail, Debug)]
@@ -85,8 +107,12 @@ fn decode_variable<R: Read>(reader: &mut R) -> Result<u64, Error> {
 
     let mut j = 0;
     loop {
+        if j > 9 {
+            // if j * 7 > 64
+            return Err(DecodeError::new("Overflow when decoding integer value").into())
+        }
         reader.read_exact(&mut buf[..])?;
-        i |= (u64::from(buf[0] & 0x7F)) << (j * 7); // TODO overflow
+        i |= (u64::from(buf[0] & 0x7F)) << (j * 7);
         if (buf[0] >> 7) == 0 {
             break
         } else {
@@ -95,6 +121,35 @@ fn decode_variable<R: Read>(reader: &mut R) -> Result<u64, Error> {
     }
 
     Ok(i)
+}
+
+/// Set a new maximum number of bytes that can be allocated when decoding data.
+/// Once called, the limit cannot be changed.
+///
+/// **NOTE** This function must be called before decoding **any** data. The
+/// library leverages [`std::sync::Once`](https://doc.rust-lang.org/std/sync/struct.Once.html)
+/// to set the limit either when calling this method, or when decoding for
+/// the first time.
+pub fn max_allocation_bytes(num_bytes: usize) -> usize {
+    unsafe {
+        MAX_ALLOCATION_BYTES_ONCE.call_once(|| {
+            MAX_ALLOCATION_BYTES = num_bytes;
+        });
+        MAX_ALLOCATION_BYTES
+    }
+}
+
+pub fn safe_len(len: usize) -> Result<usize, Error> {
+    let max_bytes = max_allocation_bytes(512 * 1024 * 1024);
+
+    if len <= max_bytes {
+        Ok(len)
+    } else {
+        Err(AllocationError::new(format!(
+            "Unable to allocate {} bytes (Maximum allowed: {})",
+            len, max_bytes
+        )).into())
+    }
 }
 
 #[cfg(test)]
@@ -108,5 +163,17 @@ mod tests {
         zig_i32(42i32, &mut a);
         zig_i64(42i64, &mut b);
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_overflow() {
+        let causes_left_shift_overflow: &[u8] = &[0xe1, 0xe1, 0xe1, 0xe1, 0xe1];
+        assert!(decode_variable(&mut &causes_left_shift_overflow[..]).is_err());
+    }
+
+    #[test]
+    fn test_safe_len() {
+        assert_eq!(42usize, safe_len(42usize).unwrap());
+        assert!(safe_len(1024 * 1024 * 1024).is_err());
     }
 }


### PR DESCRIPTION
Fixes #40

Upon bogus input data, decoding could allocate an insane amount of
memory (if length field is misencoded to a huge number) and panic.
To avoid this behaviour, this change introduces a limit (default 512MB)
to any allocation that can be done when decoding data.

Also return errors when decoding bogus int/long causing overflows.

Benchmark don't seem impacted by the change

```
New
running 14 tests
test bench_big_schema_read_100000_record   ... bench: 122,871,823 ns/iter (+/- 9,714,148)
test bench_big_schema_read_10000_record    ... bench:  12,737,304 ns/iter (+/- 2,848,853)
test bench_big_schema_read_100_record      ... bench:     134,765 ns/iter (+/- 19,624)
test bench_big_schema_read_1_record        ... bench:      16,293 ns/iter (+/- 7,916)
test bench_big_schema_write_10000_record   ... bench:   3,403,443 ns/iter (+/- 1,774,628)
test bench_big_schema_write_100_record     ... bench:      26,402 ns/iter (+/- 11,252)
test bench_big_schema_write_1_record       ... bench:       4,644 ns/iter (+/- 2,646)
test bench_file_quickstop_null             ... bench:   3,758,407 ns/iter (+/- 1,489,760)
test bench_small_schema_read_10000_record  ... bench:   1,803,131 ns/iter (+/- 211,538)
test bench_small_schema_read_100_record    ... bench:      20,728 ns/iter (+/- 16,671)
test bench_small_schema_read_1_record      ... bench:       3,730 ns/iter (+/- 2,076)
test bench_small_schema_write_10000_record ... bench:     342,308 ns/iter (+/- 148,995)
test bench_small_schema_write_100_record   ... bench:       5,753 ns/iter (+/- 2,938)
test bench_small_schema_write_1_record     ... bench:       2,418 ns/iter (+/- 1,512)

test result: ok. 0 passed; 0 failed; 0 ignored; 14 measured; 0 filtered out

     Running target/release/deps/serde_json-3308dbc1bdb10823

running 1 test
test bench_big_schema_json_read_10000_record ... bench:  43,558,406 ns/iter (+/- 8,259,033)

running 14 tests
test bench_big_schema_read_100000_record   ... bench: 122,871,823 ns/iter (+/- 9,714,148)
test bench_big_schema_read_10000_record    ... bench:  12,737,304 ns/iter (+/- 2,848,853)
test bench_big_schema_read_100_record      ... bench:     134,765 ns/iter (+/- 19,624)
test bench_big_schema_read_1_record        ... bench:      16,293 ns/iter (+/- 7,916)
test bench_big_schema_write_10000_record   ... bench:   3,403,443 ns/iter (+/- 1,774,628)
test bench_big_schema_write_100_record     ... bench:      26,402 ns/iter (+/- 11,252)
test bench_big_schema_write_1_record       ... bench:       4,644 ns/iter (+/- 2,646)
test bench_file_quickstop_null             ... bench:   3,758,407 ns/iter (+/- 1,489,760)
test bench_small_schema_read_10000_record  ... bench:   1,803,131 ns/iter (+/- 211,538)
test bench_small_schema_read_100_record    ... bench:      20,728 ns/iter (+/- 16,671)
test bench_small_schema_read_1_record      ... bench:       3,730 ns/iter (+/- 2,076)
test bench_small_schema_write_10000_record ... bench:     342,308 ns/iter (+/- 148,995)
test bench_small_schema_write_100_record   ... bench:       5,753 ns/iter (+/- 2,938)
test bench_small_schema_write_1_record     ... bench:       2,418 ns/iter (+/- 1,512)

test result: ok. 0 passed; 0 failed; 0 ignored; 14 measured; 0 filtered out

     Running target/release/deps/serde_json-3308dbc1bdb10823

running 1 test
test bench_big_schema_json_read_10000_record ... bench:  43,558,406 ns/iter (+/- 8,259,033)

test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out

     Running target/release/deps/single-ed0c4c0d15cd731f

running 2 tests
test bench_big_schema_write_record   ... bench:       1,470 ns/iter (+/- 208)
test bench_small_schema_write_record ... bench:         216 ns/iter (+/- 58)
```


```
master
running 14 tests
test bench_big_schema_read_100000_record   ... bench: 128,860,834 ns/iter (+/- 14,941,030)
test bench_big_schema_read_10000_record    ... bench:  12,426,272 ns/iter (+/- 1,840,947)
test bench_big_schema_read_100_record      ... bench:     145,451 ns/iter (+/- 25,811)
test bench_big_schema_read_1_record        ... bench:      16,981 ns/iter (+/- 5,188)
test bench_big_schema_write_10000_record   ... bench:   2,682,114 ns/iter (+/- 554,021)
test bench_big_schema_write_100_record     ... bench:      29,087 ns/iter (+/- 8,408)
test bench_big_schema_write_1_record       ... bench:       4,711 ns/iter (+/- 2,229)
test bench_file_quickstop_null             ... bench:   4,171,361 ns/iter (+/- 5,748,732)
test bench_small_schema_read_10000_record  ... bench:   2,255,414 ns/iter (+/- 1,124,975)
test bench_small_schema_read_100_record    ... bench:      23,436 ns/iter (+/- 12,716)
test bench_small_schema_read_1_record      ... bench:       4,151 ns/iter (+/- 4,216)
test bench_small_schema_write_10000_record ... bench:     397,890 ns/iter (+/- 88,784)
test bench_small_schema_write_100_record   ... bench:       6,349 ns/iter (+/- 1,322)
test bench_small_schema_write_1_record     ... bench:       2,400 ns/iter (+/- 577)

test result: ok. 0 passed; 0 failed; 0 ignored; 14 measured; 0 filtered out

     Running target/release/deps/serde_json-e71f91dffbbddc9a

running 1 test
test bench_big_schema_json_read_10000_record ... bench:  41,608,440 ns/iter (+/- 16,529,868)

test result: ok. 0 passed; 0 failed; 0 ignored; 1 measured; 0 filtered out

     Running target/release/deps/single-d0d7f7569f4fedb1

running 2 tests
test bench_big_schema_write_record   ... bench:       1,289 ns/iter (+/- 451)
test bench_small_schema_write_record ... bench:         176 ns/iter (+/- 19)
```

`make lint` decided to change a bunch of stuff. Changes don't look terrible :)