### PR TITLE
Add `to_value` to the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Added
+- Support for Parsing Canonical Form
+- `to_value` to serialize anything that implements Serialize into a Value
 
 ## [0.4.1] - 2018-06-17
 ### Changed

--- a/examples/to_value.rs
+++ b/examples/to_value.rs
@@ -1,0 +1,21 @@
+extern crate avro_rs;
+
+#[macro_use]
+extern crate serde_derive;
+extern crate failure;
+
+use avro_rs::to_value;
+use failure::Error;
+
+#[derive(Debug, Deserialize, Serialize)]
+struct Test {
+    a: i64,
+    b: String,
+}
+
+fn main() -> Result<(), Error> {
+    let test = Test { a: 27, b: "foo".to_owned() };
+    println!("{:?}", to_value(test)?);
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -524,6 +524,7 @@ pub use codec::Codec;
 pub use de::from_value;
 pub use reader::{from_avro_datum, Reader};
 pub use schema::{ParseSchemaError, Schema};
+pub use ser::to_value;
 pub use types::SchemaResolutionError;
 pub use util::{max_allocation_bytes, DecodeError};
 pub use writer::{to_avro_datum, ValidationError, Writer};

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -401,7 +401,34 @@ impl ser::SerializeStructVariant for StructSerializer {
     }
 }
 
+/// Interpret a serializeable instance as a `Value`.
+///
+/// This conversion can fail if the value is not valid as per the Avro specification.
+/// e.g: HashMap with non-string keys
 pub fn to_value<S: Serialize>(value: S) -> Result<Value, Error> {
     let mut serializer = Serializer::default();
     value.serialize(&mut serializer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct Test {
+        a: i64,
+        b: String,
+    }
+
+    #[test]
+    fn test_to_value() {
+        let test = Test { a: 27, b: "foo".to_owned() };
+        let expected = Value::Record(
+            vec![
+                ("a".to_owned(), Value::Long(27)),
+                ("b".to_owned(), Value::String("foo".to_owned())),
+            ]);
+
+        assert_eq!(to_value(test).unwrap(), expected);
+    }
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -400,3 +400,8 @@ impl ser::SerializeStructVariant for StructSerializer {
         unimplemented!()
     }
 }
+
+pub fn to_value<S: Serialize>(value: S) -> Result<Value, Error> {
+    let mut serializer = Serializer::default();
+    value.serialize(&mut serializer)
+}


### PR DESCRIPTION
Reciprocal function of `from_value`.

Fixes #45 