### PR TITLE
Fix encoding of empty Array/Map

### DIFF
--- a/examples/to_value.rs
+++ b/examples/to_value.rs
@@ -14,7 +14,10 @@ struct Test {
 }
 
 fn main() -> Result<(), Error> {
-    let test = Test { a: 27, b: "foo".to_owned() };
+    let test = Test {
+        a: 27,
+        b: "foo".to_owned(),
+    };
     println!("{:?}", to_value(test)?);
 
     Ok(())

--- a/src/de.rs
+++ b/src/de.rs
@@ -316,9 +316,11 @@ impl<'de> de::MapAccess<'de> for MapDeserializer<'de> {
         K: DeserializeSeed<'de>,
     {
         match self.input_keys.next() {
-            Some(ref key) => seed.deserialize(StringDeserializer {
-                input: (*key).clone(),
-            }).map(Some),
+            Some(ref key) => {
+                seed.deserialize(StringDeserializer {
+                    input: (*key).clone(),
+                }).map(Some)
+            },
             None => Ok(None),
         }
     }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -63,19 +63,23 @@ pub fn encode_ref(value: &Value, schema: &Schema, buffer: &mut Vec<u8>) {
         },
         Value::Array(items) => {
             if let Schema::Array(ref inner) = *schema {
-                encode_long(items.len() as i64, buffer);
-                for item in items.iter() {
-                    encode_ref(item, inner, buffer);
+                if items.len() > 0 {
+                    encode_long(items.len() as i64, buffer);
+                    for item in items.iter() {
+                        encode_ref(item, inner, buffer);
+                    }
                 }
                 buffer.push(0u8);
             }
         },
         Value::Map(items) => {
             if let Schema::Map(ref inner) = *schema {
-                encode_long(items.len() as i64, buffer);
-                for (key, value) in items {
-                    encode_bytes(key, buffer);
-                    encode_ref(value, inner, buffer);
+                if items.len() > 0 {
+                    encode_long(items.len() as i64, buffer);
+                    for (key, value) in items {
+                        encode_bytes(key, buffer);
+                        encode_ref(value, inner, buffer);
+                    }
                 }
                 buffer.push(0u8);
             }
@@ -98,4 +102,27 @@ pub fn encode_to_vec(value: &Value, schema: &Schema) -> Vec<u8> {
     let mut buffer = Vec::new();
     encode(&value, schema, &mut buffer);
     buffer
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::rc::Rc;
+
+    #[test]
+    fn test_encode_empty_array() {
+        let mut buf = Vec::new();
+        let empty: Vec<Value> = Vec::new();
+        encode(&Value::Array(empty), &Schema::Array(Rc::new(Schema::Int)), &mut buf);
+        assert_eq!(vec![0u8], buf);
+    }
+
+    #[test]
+    fn test_encode_empty_map() {
+        let mut buf = Vec::new();
+        let empty: HashMap<String, Value> = HashMap::new();
+        encode(&Value::Map(empty), &Schema::Map(Rc::new(Schema::Int)), &mut buf);
+        assert_eq!(vec![0u8], buf);
+    }
 }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -114,7 +114,11 @@ mod tests {
     fn test_encode_empty_array() {
         let mut buf = Vec::new();
         let empty: Vec<Value> = Vec::new();
-        encode(&Value::Array(empty), &Schema::Array(Rc::new(Schema::Int)), &mut buf);
+        encode(
+            &Value::Array(empty),
+            &Schema::Array(Rc::new(Schema::Int)),
+            &mut buf,
+        );
         assert_eq!(vec![0u8], buf);
     }
 
@@ -122,7 +126,11 @@ mod tests {
     fn test_encode_empty_map() {
         let mut buf = Vec::new();
         let empty: HashMap<String, Value> = HashMap::new();
-        encode(&Value::Map(empty), &Schema::Map(Rc::new(Schema::Int)), &mut buf);
+        encode(
+            &Value::Map(empty),
+            &Schema::Map(Rc::new(Schema::Int)),
+            &mut buf,
+        );
         assert_eq!(vec![0u8], buf);
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -57,7 +57,8 @@ impl<R: Read> Block<R> {
 
         if let Value::Map(meta) = decode(&meta_schema, &mut self.reader)? {
             // TODO: surface original parse schema errors instead of coalescing them here
-            let schema = meta.get("avro.schema")
+            let schema = meta
+                .get("avro.schema")
                 .and_then(|bytes| {
                     if let Value::Bytes(ref bytes) = *bytes {
                         from_slice(bytes.as_ref()).ok()
@@ -72,7 +73,8 @@ impl<R: Read> Block<R> {
                 return Err(ParseSchemaError::new("unable to parse schema").into())
             }
 
-            if let Some(codec) = meta.get("avro.codec")
+            if let Some(codec) = meta
+                .get("avro.codec")
                 .and_then(|codec| {
                     if let Value::Bytes(ref bytes) = *codec {
                         from_utf8(bytes.as_ref()).ok()

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -422,12 +422,14 @@ mod tests {
 
     #[test]
     fn test_to_value() {
-        let test = Test { a: 27, b: "foo".to_owned() };
-        let expected = Value::Record(
-            vec![
-                ("a".to_owned(), Value::Long(27)),
-                ("b".to_owned(), Value::String("foo".to_owned())),
-            ]);
+        let test = Test {
+            a: 27,
+            b: "foo".to_owned(),
+        };
+        let expected = Value::Record(vec![
+            ("a".to_owned(), Value::Long(27)),
+            ("b".to_owned(), Value::String("foo".to_owned())),
+        ]);
 
         assert_eq!(to_value(test).unwrap(), expected);
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -457,10 +457,12 @@ impl Value {
 
     fn resolve_array(self, schema: &Schema) -> Result<Self, Error> {
         match self {
-            Value::Array(items) => Ok(Value::Array(items
-                .into_iter()
-                .map(|item| item.resolve(schema))
-                .collect::<Result<Vec<_>, _>>()?)),
+            Value::Array(items) => Ok(Value::Array(
+                items
+                    .into_iter()
+                    .map(|item| item.resolve(schema))
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
             other => Err(SchemaResolutionError::new(format!(
                 "Array({:?}) expected, got {:?}",
                 schema, other
@@ -470,10 +472,12 @@ impl Value {
 
     fn resolve_map(self, schema: &Schema) -> Result<Self, Error> {
         match self {
-            Value::Map(items) => Ok(Value::Map(items
-                .into_iter()
-                .map(|(key, value)| value.resolve(schema).map(|value| (key, value)))
-                .collect::<Result<HashMap<_, _>, _>>()?)),
+            Value::Map(items) => Ok(Value::Map(
+                items
+                    .into_iter()
+                    .map(|(key, value)| value.resolve(schema).map(|value| (key, value)))
+                    .collect::<Result<HashMap<_, _>, _>>()?,
+            )),
             other => Err(SchemaResolutionError::new(format!(
                 "Map({:?}) expected, got {:?}",
                 schema, other
@@ -651,25 +655,33 @@ mod tests {
             ]).validate(&schema)
         );
 
-        assert!(!Value::Record(vec![
-            ("b".to_string(), Value::String("foo".to_string())),
-            ("a".to_string(), Value::Long(42i64)),
-        ]).validate(&schema));
+        assert!(
+            !Value::Record(vec![
+                ("b".to_string(), Value::String("foo".to_string())),
+                ("a".to_string(), Value::Long(42i64)),
+            ]).validate(&schema)
+        );
 
-        assert!(!Value::Record(vec![
-            ("a".to_string(), Value::Boolean(false)),
-            ("b".to_string(), Value::String("foo".to_string())),
-        ]).validate(&schema));
+        assert!(
+            !Value::Record(vec![
+                ("a".to_string(), Value::Boolean(false)),
+                ("b".to_string(), Value::String("foo".to_string())),
+            ]).validate(&schema)
+        );
 
-        assert!(!Value::Record(vec![
-            ("a".to_string(), Value::Long(42i64)),
-            ("c".to_string(), Value::String("foo".to_string())),
-        ]).validate(&schema));
+        assert!(
+            !Value::Record(vec![
+                ("a".to_string(), Value::Long(42i64)),
+                ("c".to_string(), Value::String("foo".to_string())),
+            ]).validate(&schema)
+        );
 
-        assert!(!Value::Record(vec![
-            ("a".to_string(), Value::Long(42i64)),
-            ("b".to_string(), Value::String("foo".to_string())),
-            ("c".to_string(), Value::Null),
-        ]).validate(&schema));
+        assert!(
+            !Value::Record(vec![
+                ("a".to_string(), Value::Long(42i64)),
+                ("b".to_string(), Value::String("foo".to_string())),
+                ("c".to_string(), Value::Null),
+            ]).validate(&schema)
+        );
     }
 }


### PR DESCRIPTION
When a container is empty, only `0u8` has to be encoded, to signal the
end of the container.

Fixes #49 

Also run `make lint`