### PR TITLE
Fix large magnitude long value serialization

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -68,7 +68,7 @@ pub fn zig_i32(n: i32, buffer: &mut Vec<u8>) {
 }
 
 pub fn zig_i64(n: i64, buffer: &mut Vec<u8>) {
-    encode_variable((n << 1) ^ (n >> 31), buffer)
+    encode_variable((n << 1) ^ (n >> 63), buffer)
 }
 
 pub fn zag_i32<R: Read>(reader: &mut R) -> Result<i32, Error> {
@@ -163,6 +163,25 @@ mod tests {
         zig_i32(42i32, &mut a);
         zig_i64(42i64, &mut b);
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_zig_i64() {
+        let mut s = Vec::new();
+        zig_i64(2147483647i64, &mut s);
+        assert_eq!(s, [254, 255, 255, 255, 15]);
+
+        s.clear();
+        zig_i64(2147483648i64, &mut s);
+        assert_eq!(s, [128, 128, 128, 128, 16]);
+
+        s.clear();
+        zig_i64(-2147483648i64, &mut s);
+        assert_eq!(s, [255, 255, 255, 255, 15]);
+
+        s.clear();
+        zig_i64(-2147483649i64, &mut s);
+        assert_eq!(s, [129, 128, 128, 128, 16]);
     }
 
     #[test]


### PR DESCRIPTION
Serialization of 64-bit numbers is incorrect for large-magnitude values because the code currently shifts thirty-one bits to the right, instead of sixty-three. Serialization is incorrect for:
- Positive numbers with the thirty-second, or above, bit set (i.e., >= 2147483648).
- Negative numbers with the thirty-second, or above, bit not set (i.e., <= -2147483649).

| Value | avro-rs (serialized, deserialized) | C Avro | fastavro (Python) |
| ------------- | ------------- | ------------- | ------------- |
| 2147483647  | ✅ fe ff ff ff 0f, 2147483647 | fe ff ff ff 0f | fe ff ff ff 0f |
| 2147483648  | ❌81 80 80 80 10, -2147483649 | 80 80 80 80 10 | 80 80 80 80 10 |
| -2147483648 | ✅ ff ff ff ff 0f, -2147483648  | ff ff ff ff 0f | ff ff ff ff 0f |
| -2147483649 | ❌80 80 80 80 10, 2147483648 | 81 80 80 80 10 | 81 80 80 80 10 |

For comparison, the relevant line from the C Avro implementation is [here](https://github.com/apache/avro/blob/cf2f30336efe0ecc3debc7bede86fde6d23f7c79/lang/c/src/encoding_binary.c#L71).