### PR TITLE
Convert i32 to i64 earlier during serialization

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -64,7 +64,7 @@ pub fn read_long<R: Read>(reader: &mut R) -> Result<i64, Error> {
 }
 
 pub fn zig_i32(n: i32, buffer: &mut Vec<u8>) {
-    encode_variable(i64::from((n << 1) ^ (n >> 31)), buffer)
+    zig_i64(n as i64, buffer)
 }
 
 pub fn zig_i64(n: i64, buffer: &mut Vec<u8>) {
@@ -182,6 +182,33 @@ mod tests {
         s.clear();
         zig_i64(-2147483649i64, &mut s);
         assert_eq!(s, [129, 128, 128, 128, 16]);
+    }
+
+    #[test]
+    fn test_zig_i32() {
+        let mut s = Vec::new();
+        zig_i32(1073741823i32, &mut s);
+        assert_eq!(s, [254, 255, 255, 255, 7]);
+
+        s.clear();
+        zig_i32(-1073741824i32, &mut s);
+        assert_eq!(s, [255, 255, 255, 255, 7]);
+
+        s.clear();
+        zig_i32(1073741824i32, &mut s);
+        assert_eq!(s, [128, 128, 128, 128, 8]);
+
+        s.clear();
+        zig_i32(-1073741825i32, &mut s);
+        assert_eq!(s, [129, 128, 128, 128, 8]);
+
+        s.clear();
+        zig_i32(2147483647i32, &mut s);
+        assert_eq!(s, [254, 255, 255, 255, 15]);
+
+        s.clear();
+        zig_i32(-2147483648i32, &mut s);
+        assert_eq!(s, [255, 255, 255, 255, 15]);
     }
 
     #[test]


### PR DESCRIPTION
The current implementation of `zig_i32` does its bit shift operations before converting the value being serialized to i64. This means that i32 serialization is incorrect for:
- Positive values with the 31st bit set (i.e., >= 1073741824).
- Negative values with the 31st bit not set (i.e., <= -1073741825).

Here is the current 32-bit serialization for values along those boundaries:

| Value | avro-rs (serialized, deserialized) | C Avro | fastavro (Python) |
| ------------- | ------------- | ------------- | ------------- |
| 1073741823  | ✅ fe ff ff ff 07, 1073741823 | fe ff ff ff 07 | fe ff ff ff 07 |
| 1073741824  | ❌ 00, 0 | 80 80 80 80 08 | 80 80 80 80 08 |
| -1073741824 | ✅ ff ff ff ff 07, -1073741824  | ff ff ff ff 07 | ff ff ff ff 07 |
| -1073741825 | ❌ 01, -1 | 81 80 80 80 08 | 81 80 80 80 08 |


By expanding to 64 bits earlier, we can correctly serialize the full range of 32-bit integers. This is the approach taken in C Avro ([here](https://github.com/apache/avro/blob/cf2f30336efe0ecc3debc7bede86fde6d23f7c79/lang/c/src/encoding_binary.c#L115)), for instance. This PR makes that change.

After the change:

| Value | avro-rs |
| ------------- | ------------- |
| 1073741823 | ✅ fe ff ff ff 07 |
| 1073741824 | ✅ 80 80 80 80 08 |
| -1073741824 | ✅ ff ff ff ff 07 |
| -1073741825 | ✅ 81 80 80 80 08 |
