### PR TITLE
Add fingerprinting generation to library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ snappy = ["byteorder", "crc", "snap"]
 [dependencies]
 byteorder = { version = "1.0.0", optional = true }
 crc = { version = "1.3.0", optional = true }
+digest = "0.8"
 failure = "0.1.1"
 failure_derive = "0.1.1"
 libflate = "0.1"
@@ -23,4 +24,6 @@ serde_json = "1.0"
 snap = { version = "0.2.3", optional = true }
 
 [dev-dependencies]
+md-5 = "0.8"
 lazy_static = "^1.1"
+sha2 = "0.8"

--- a/README.md
+++ b/README.md
@@ -84,6 +84,46 @@ fn main() -> Result<(), Error> {
 }
 ```
 
+### Calculate Avro schema fingerprint
+
+This library supports calculating the following fingerprints:
+
+ - SHA-256
+ - MD5
+
+Note: Rabin fingerprinting is NOT SUPPORTED yet.
+
+An example of fingerprinting for the supported fingerprints:
+
+```rust
+extern crate avro_rs;
+extern crate failure;
+extern crate md5;
+extern crate sha2;
+
+use avro_rs::Schema;
+use failure::Error;
+use md5::Md5;
+use sha2::Sha256;
+
+fn main() -> Result<(), Error> {
+    let raw_schema = r#"
+        {
+            "type": "record",
+            "name": "test",
+            "fields": [
+                {"name": "a", "type": "long", "default": 42},
+                {"name": "b", "type": "string"}
+            ]
+        }
+    "#;
+    let schema = Schema::parse_str(raw_schema)?;
+    println!("{}", schema.fingerprint::<Sha256>());
+    println!("{}", schema.fingerprint::<Md5>());
+    Ok(())
+}
+```
+
 ### Ill-formed data
 
 In order to ease decoding, the Binary Encoding specification of Avro data

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -491,6 +491,7 @@
 //! }
 //! ```
 
+extern crate digest;
 extern crate failure;
 #[macro_use]
 extern crate failure_derive;


### PR DESCRIPTION
Added SHA-256 and MD5 but haven't added Rabin due to lack of a well supported library. May
be implemented at a later phase either directly here or by creating a library to calculate
it.