### PR TITLE
Partial Rust Enum Serialization/Deserialization Support

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -632,41 +632,6 @@ mod tests {
     }
 
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    struct TestSingleValueInternalEnum {
-        a: SingleValueInternalEnum,
-    }
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    #[serde(tag = "t")]
-    enum SingleValueInternalEnum {
-        Double(f64),
-        String(String),
-    }
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    struct TestSingleValueAdjacentEnum {
-        a: SingleValueAdjacentEnum,
-    }
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    #[serde(tag = "t", content = "v")]
-    enum SingleValueAdjacentEnum {
-        Double(f64),
-        String(String),
-    }
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    struct TestSingleValueUntaggedEnum {
-        a: SingleValueUntaggedEnum,
-    }
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    #[serde(untagged)]
-    enum SingleValueUntaggedEnum {
-        Double(f64),
-        String(String),
-    }
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct TestStructExternalEnum {
         a: StructExternalEnum,
     }
@@ -678,74 +643,12 @@ mod tests {
     }
 
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    struct TestStructInternalEnum {
-        a: StructInternalEnum,
-    }
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    #[serde(tag = "type")]
-    enum StructInternalEnum {
-        Val1 { x: f32, y: f32 },
-        Val2 { x: f32, y: f32 },
-    }
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    struct TestStructAdjacentEnum {
-        a: StructAdjacentEnum,
-    }
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    #[serde(tag = "t", content = "v")]
-    enum StructAdjacentEnum {
-        Val1 { x: f32, y: f32 },
-        Val2 { x: f32, y: f32 },
-    }
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    struct TestStructUntaggedEnum {
-        a: StructUntaggedEnum,
-    }
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    #[serde(untagged)]
-    enum StructUntaggedEnum {
-        Val1 { x: f32, y: f32 },
-        Val2 { x: f32, y: f32, z: f32 },
-    }
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct TestTupleExternalEnum {
         a: TupleExternalEnum,
     }
 
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     enum TupleExternalEnum {
-        Val1(f32, f32),
-        Val2(f32, f32, f32),
-    }
-
-    // Tuple Internal Enum cannot be instantiated
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    struct TestTupleAdjacentEnum {
-        a: TupleAdjacentEnum,
-    }
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    #[serde(tag = "t", content = "v")]
-    enum TupleAdjacentEnum {
-        Val1(f32, f32),
-        Val2(f32, f32, f32),
-    }
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    struct TestTupleUntaggedEnum {
-        a: TupleUntaggedEnum,
-    }
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    #[serde(untagged)]
-    enum TupleUntaggedEnum {
         Val1(f32, f32),
         Val2(f32, f32, f32),
     }

--- a/src/de.rs
+++ b/src/de.rs
@@ -829,13 +829,6 @@ mod tests {
             a: SingleValueExternalEnum::Double(64.0)
         };
 
-        // let test = Value::Record(vec![
-        //     ("a".to_owned(), Value::Record(vec![
-        //         ("Double".to_owned(), Value::Double(64.0))
-        //     ]))
-        // ]);
-        // let final_value: TestSingleValueExternalEnum = from_value(&test).unwrap();
-        // assert_eq!(final_value, expected, "Error deserializing single value external enum");
         let test = Value::Record(vec![
             ("a".to_owned(), Value::Record(vec![
                 ("type".to_owned(), Value::String("Double".to_owned())),
@@ -844,31 +837,6 @@ mod tests {
         ]);
         let final_value: TestSingleValueExternalEnum = from_value(&test).unwrap();
         assert_eq!(final_value, expected, "Error deserializing single value external enum(union)");
-
-        // It is not possible to serialize an internal Single Value enum...
-
-        // let expected = TestSingleValueAdjacentEnum {
-        //     a: SingleValueAdjacentEnum::Double(64.0)
-        // };
-
-        // let test = Value::Record(vec![
-        //     ("a".to_owned(), Value::Record(vec![
-        //         ("t".to_owned(), Value::String("Double".to_owned())),
-        //         ("v".to_owned(), Value::Double(64.0))
-        //     ]))
-        // ]);
-        // let final_value: TestSingleValueAdjacentEnum = from_value(&test).unwrap();
-        // assert_eq!(final_value, expected, "Error deserializing single value adjacent enum");
-
-        // let expected = TestSingleValueUntaggedEnum {
-        //     a: SingleValueUntaggedEnum::Double(64.0)
-        // };
-
-        // let test = Value::Record(vec![
-        //     ("a".to_owned(), Value::Double(64.0))
-        // ]);
-        // let final_value: TestSingleValueUntaggedEnum = from_value(&test).unwrap();
-        // assert_eq!(final_value, expected, "Error deserializing single value untagged enum");
     }
 
     #[test]
@@ -876,17 +844,6 @@ mod tests {
         let expected = TestStructExternalEnum {
             a: StructExternalEnum::Val1 {x: 1.0, y: 2.0}
         };
-
-        // let test = Value::Record(vec![
-        //     ("a".to_owned(), Value::Record(vec![
-        //         ("Val1".to_owned(), Value::Record(vec![
-        //             ("x".to_owned(), Value::Float(1.0)),
-        //             ("y".to_owned(), Value::Float(2.0)),
-        //         ]))
-        //     ]))
-        // ]);
-        // let final_value: TestStructExternalEnum = from_value(&test).unwrap();
-        // assert_eq!(final_value, expected, "error deserializing struct external enum");
 
         let test = Value::Record(vec![
             ("a".to_owned(), Value::Record(vec![
@@ -899,61 +856,6 @@ mod tests {
         ]);
         let final_value: TestStructExternalEnum = from_value(&test).unwrap();
         assert_eq!(final_value, expected, "error deserializing struct external enum(union)");
-
-        // let expected = TestStructInternalEnum {
-        //     a: StructInternalEnum::Val1 {x: 1.0, y: 2.0}
-        // };
-        // let test = Value::Record(vec![
-        //     ("a".to_owned(), Value::Record(vec![
-        //         ("type".to_owned(), Value::String("Val1".to_owned())),
-        //         ("x".to_owned(), Value::Float(1.0)),
-        //         ("y".to_owned(), Value::Float(2.0)),
-        //     ]))
-        // ]);
-        // let final_value: TestStructInternalEnum = from_value(&test).unwrap();
-        // assert_eq!(final_value, expected, "error deserializing struct internal enum");
-
-        // let expected = TestStructAdjacentEnum {
-        //     a: StructAdjacentEnum::Val1 {x: 1.0, y: 2.0}
-        // };
-        // let test = Value::Record(vec![
-        //     ("a".to_owned(), Value::Record(vec![
-        //         ("t".to_owned(), Value::String("Val1".to_owned())),
-        //         ("v".to_owned(), Value::Record(vec![
-        //             ("x".to_owned(), Value::Float(1.0)),
-        //             ("y".to_owned(), Value::Float(2.0)),
-        //         ]))
-        //     ]))
-        // ]);
-        // let final_value: TestStructAdjacentEnum = from_value(&test).unwrap();
-        // assert_eq!(final_value, expected, "error deserializing struct adjacent enum");
-
-        // let expected = TestStructUntaggedEnum {
-        //     a: StructUntaggedEnum::Val1 {x: 1.0, y: 2.0}
-        // };
-        // let test = Value::Record(vec![
-        //     ("a".to_owned(), Value::Record(vec![
-        //         ("x".to_owned(), Value::Float(1.0)),
-        //         ("y".to_owned(), Value::Float(2.0)),
-        //     ]))
-        // ]);
-        // let final_value: TestStructUntaggedEnum = from_value(&test).unwrap();
-        // assert_eq!(final_value, expected, "error deserializing struct untagged enum");
-
-        // There is an issue in serde when deserializing untagged struct enum where it will choose
-        // The first one that fits, before finishing processing the full record.
-        // let expected = TestStructUntaggedEnum {
-        //     a: StructUntaggedEnum::Val1 {x: 1.0, y: 2.0}
-        // };
-        // let test = Value::Record(vec![
-        //     ("a".to_owned(), Value::Record(vec![
-        //         ("x".to_owned(), Value::Float(1.0)),
-        //         ("y".to_owned(), Value::Float(2.0)),
-        //         ("z".to_owned(), Value::Float(3.0)),
-        //     ]))
-        // ]);
-        // let final_value: TestStructUntaggedEnum = from_value(&test).unwrap();
-        // assert_eq!(final_value, expected, "error deserializing struct untagged enum variant");
     }
 
     #[test]
@@ -961,14 +863,6 @@ mod tests {
         let expected = TestTupleExternalEnum {
             a: TupleExternalEnum::Val1(1.0, 2.0),
         };
-
-        // let test = Value::Record(vec![
-        //     ("a".to_owned(), Value::Record(vec![
-        //         ("Val1".to_owned(), Value::Array(vec![Value::Float(1.0), Value::Float(2.0)]))
-        //     ]))
-        // ]);
-        // let final_value: TestTupleExternalEnum = from_value(&test).unwrap();
-        // assert_eq!(final_value, expected, "error serializing tuple external enum");
 
         let test = Value::Record(vec![
             ("a".to_owned(), Value::Record(vec![
@@ -978,28 +872,5 @@ mod tests {
         ]);
         let final_value: TestTupleExternalEnum = from_value(&test).unwrap();
         assert_eq!(final_value, expected, "error serializing tuple external enum(union)");
-
-        // let expected = TestTupleAdjacentEnum {
-        //     a: TupleAdjacentEnum::Val1(1.0, 2.0),
-        // };
-
-        // let test = Value::Record(vec![
-        //     ("a".to_owned(), Value::Record(vec![
-        //         ("t".to_owned(), Value::String("Val1".to_owned())),
-        //         ("v".to_owned(), Value::Array(vec![Value::Float(1.0), Value::Float(2.0)]))
-        //     ]))
-        // ]);
-        // let final_value: TestTupleAdjacentEnum = from_value(&test).unwrap();
-        // assert_eq!(final_value, expected, "error serializing tuple adjacent enum");
-
-        // let expected = TestTupleUntaggedEnum {
-        //     a: TupleUntaggedEnum::Val1(1.0, 2.0),
-        // };
-
-        // let test = Value::Record(vec![
-        //     ("a".to_owned(), Value::Array(vec![Value::Float(1.0), Value::Float(2.0)]))
-        // ]);
-        // let final_value: TestTupleUntaggedEnum = from_value(&test).unwrap();
-        // assert_eq!(final_value, expected, "error serializing tuple untagged enum");
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -164,7 +164,7 @@ impl<'de> de::EnumAccess<'de> for EnumDeserializer<'de> {
         self.input
             .first()
             .map_or(
-                Err(Error::custom("Should not get here")),
+                Err(Error::custom("A record must have a least one field")),
                 |item| Ok((seed.deserialize(StringDeserializer {input: item.0.clone()})?, self))
             )
     }
@@ -184,7 +184,7 @@ impl<'de> de::VariantAccess<'de> for EnumDeserializer<'de> {
         self.input
             .first()
             .map_or(
-                Err(Error::custom("Expected a newtype variant, got nothing instead")),
+                Err(Error::custom("Expected a newtype variant, got nothing instead.")),
                 |item| seed.deserialize(&Deserializer::new(&item.1)))
     }
 
@@ -195,7 +195,7 @@ impl<'de> de::VariantAccess<'de> for EnumDeserializer<'de> {
         self.input
             .first()
             .map_or(
-                Err(Error::custom("Should not get here")),        
+                Err(Error::custom("Expected a tuple variant, got nothing instead.")),        
                 |item| de::Deserializer::deserialize_seq(&Deserializer::new(&item.1), visitor)
             )
     }
@@ -211,7 +211,7 @@ impl<'de> de::VariantAccess<'de> for EnumDeserializer<'de> {
         self.input
             .first()
             .map_or(
-                Err(Error::custom("Unexpected struct variant")),
+                Err(Error::custom("Expected a struct variant, got nothing instead.")),
                 |item| de::Deserializer::deserialize_struct(&Deserializer::new(&item.1), "", fields, visitor)
             )
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -725,16 +725,14 @@ mod tests {
             ]))
         ]);
 
-        assert_eq!(to_value(test).unwrap(), expected, "Error serializing unit internal enum");
+        assert_eq!(to_value(test).unwrap(), expected, "Error serializing unit adjacent enum");
 
         let test = TestUnitUntaggedEnum {
             a: UnitUntaggedEnum::Val1,
         };
 
         let expected = Value::Record(vec![
-            ("a".to_owned(), Value::Record(vec![
-                ("t".to_owned(), Value::String("Val1".to_owned())),
-            ]))
+            ("a".to_owned(), Value::Null),
         ]);
 
         assert_eq!(to_value(test).unwrap(), expected, "Error serializing unit untagged enum");

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -360,7 +360,7 @@ impl ser::SerializeTupleVariant for SeqVariantSerializer {
     where
         T: Serialize,
     {
-            ser::SerializeSeq::serialize_element(self, value)
+        ser::SerializeSeq::serialize_element(self, value)
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -198,13 +198,17 @@ impl<'b> ser::Serializer for &'b mut Serializer {
         self,
         _: &'static str,
         _: u32,
-        _: &'static str,
+        field: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
         T: Serialize,
     {
-        value.serialize(self)
+        let final_value = Value::Record(vec![
+            ("name".into(), Value::String(field.to_owned())),
+            ("value".into(), Value::Union(Box::new(value.serialize(self)?)))
+            ]);
+        Ok(final_value)
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -768,28 +768,28 @@ mod tests {
 
         assert_eq!(to_value(test).is_err(), true);
 
-        // let test = TestSingleValueAdjacentEnum {
-        //     a: SingleValueAdjacentEnum::Double(64.0)
-        // };
+        let test = TestSingleValueAdjacentEnum {
+            a: SingleValueAdjacentEnum::Double(64.0)
+        };
 
-        // let expected = Value::Record(vec![
-        //     ("a".to_owned(), Value::Record(vec![
-        //         ("t".to_owned(), Value::String("Double".to_owned())),
-        //         ("v".to_owned(), Value::Union(Box::new(Value::Double(64.0)))),
-        //     ]))
-        // ]);
+        let expected = Value::Record(vec![
+            ("a".to_owned(), Value::Record(vec![
+                ("t".to_owned(), Value::String("Double".to_owned())),
+                ("v".to_owned(), Value::Double(64.0)),
+            ]))
+        ]);
 
-        // assert_eq!(to_value(test).unwrap(), expected, "Error serializing single value adjacent enum");
+        assert_eq!(to_value(test).unwrap(), expected, "Error serializing single value adjacent enum");
 
-        // let test = TestSingleValueUntaggedEnum {
-        //     a: SingleValueUntaggedEnum::Double(64.0)
-        // };
+        let test = TestSingleValueUntaggedEnum {
+            a: SingleValueUntaggedEnum::Double(64.0)
+        };
 
-        // let expected = Value::Record(vec![
-        //     ("a".to_owned(), Value::Union(Box::new(Value::Double(64.0))))
-        // ]);
+        let expected = Value::Record(vec![
+            ("a".to_owned(), Value::Double(64.0))
+        ]);
 
-        // assert_eq!(to_value(test).unwrap(), expected, "Error serializing single value untagged enum");
+        assert_eq!(to_value(test).unwrap(), expected, "Error serializing single value untagged enum");
     }
 
     #[test]
@@ -811,58 +811,58 @@ mod tests {
 
         // I don't think that this is feasible in avro
 
-        // let test = TestStructInternalEnum {
-        //     a: StructInternalEnum::Val1 {x: 1.0, y: 2.0}
-        // };
-        // let expected = Value::Record(vec![
-        //     ("a".to_owned(), Value::Record(vec![
-        //         ("type".to_owned(), Value::String("Val1".to_owned())),
-        //         ("x".to_owned(), Value::Float(1.0)),
-        //         ("y".to_owned(), Value::Float(2.0)),
-        //     ]))
-        // ]);
+        let test = TestStructInternalEnum {
+            a: StructInternalEnum::Val1 {x: 1.0, y: 2.0}
+        };
+        let expected = Value::Record(vec![
+            ("a".to_owned(), Value::Record(vec![
+                ("type".to_owned(), Value::String("Val1".to_owned())),
+                ("x".to_owned(), Value::Float(1.0)),
+                ("y".to_owned(), Value::Float(2.0)),
+            ]))
+        ]);
 
-        // assert_eq!(to_value(test).unwrap(), expected, "error serializing struct internal enum");
+        assert_eq!(to_value(test).unwrap(), expected, "error serializing struct internal enum");
 
-        // let test = TestStructAdjacentEnum {
-        //     a: StructAdjacentEnum::Val1 {x: 1.0, y: 2.0}
-        // };
-        // let expected = Value::Record(vec![
-        //     ("a".to_owned(), Value::Record(vec![
-        //         ("t".to_owned(), Value::String("Val1".to_owned())),
-        //         ("v".to_owned(), Value::Union(Box::new(Value::Record(vec![
-        //             ("x".to_owned(), Value::Float(1.0)),
-        //             ("y".to_owned(), Value::Float(2.0)),
-        //         ]))))
-        //     ]))
-        // ]);
+        let test = TestStructAdjacentEnum {
+            a: StructAdjacentEnum::Val1 {x: 1.0, y: 2.0}
+        };
+        let expected = Value::Record(vec![
+            ("a".to_owned(), Value::Record(vec![
+                ("t".to_owned(), Value::String("Val1".to_owned())),
+                ("v".to_owned(), Value::Record(vec![
+                    ("x".to_owned(), Value::Float(1.0)),
+                    ("y".to_owned(), Value::Float(2.0)),
+                ]))
+            ]))
+        ]);
 
-        // assert_eq!(to_value(test).unwrap(), expected, "error serializing struct adjacent enum");
+        assert_eq!(to_value(test).unwrap(), expected, "error serializing struct adjacent enum");
 
-        // let test = TestStructUntaggedEnum {
-        //     a: StructUntaggedEnum::Val1 {x: 1.0, y: 2.0}
-        // };
-        // let expected = Value::Record(vec![
-        //     ("a".to_owned(), Value::Union(Box::new(Value::Record(vec![
-        //         ("x".to_owned(), Value::Float(1.0)),
-        //         ("y".to_owned(), Value::Float(2.0)),
-        //     ]))))
-        // ]);
+        let test = TestStructUntaggedEnum {
+            a: StructUntaggedEnum::Val1 {x: 1.0, y: 2.0}
+        };
+        let expected = Value::Record(vec![
+            ("a".to_owned(), Value::Record(vec![
+                ("x".to_owned(), Value::Float(1.0)),
+                ("y".to_owned(), Value::Float(2.0)),
+            ]))
+        ]);
 
-        // assert_eq!(to_value(test).unwrap(), expected, "error serializing struct untagged enum");
+        assert_eq!(to_value(test).unwrap(), expected, "error serializing struct untagged enum");
 
-        // let test = TestStructUntaggedEnum {
-        //     a: StructUntaggedEnum::Val2 {x: 1.0, y: 2.0, z: 3.0}
-        // };
-        // let expected = Value::Record(vec![
-        //     ("a".to_owned(), Value::Union(Box::new(Value::Record(vec![
-        //         ("x".to_owned(), Value::Float(1.0)),
-        //         ("y".to_owned(), Value::Float(2.0)),
-        //         ("z".to_owned(), Value::Float(3.0)),
-        //     ]))))
-        // ]);
+        let test = TestStructUntaggedEnum {
+            a: StructUntaggedEnum::Val2 {x: 1.0, y: 2.0, z: 3.0}
+        };
+        let expected = Value::Record(vec![
+            ("a".to_owned(), Value::Record(vec![
+                ("x".to_owned(), Value::Float(1.0)),
+                ("y".to_owned(), Value::Float(2.0)),
+                ("z".to_owned(), Value::Float(3.0)),
+            ]))
+        ]);
 
-        // assert_eq!(to_value(test).unwrap(), expected, "error serializing struct untagged enum variant");
+        assert_eq!(to_value(test).unwrap(), expected, "error serializing struct untagged enum variant");
     }
 
     #[test]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -885,27 +885,27 @@ mod tests {
 
         assert_eq!(to_value(test).unwrap(), expected, "error serializing tuple external enum");
 
-        // let test = TestTupleAdjacentEnum {
-        //     a: TupleAdjacentEnum::Val1(1.0, 2.0),
-        // };
+        let test = TestTupleAdjacentEnum {
+            a: TupleAdjacentEnum::Val1(1.0, 2.0),
+        };
 
-        // let expected = Value::Record(vec![
-        //     ("a".to_owned(), Value::Record(vec![
-        //         ("t".to_owned(), Value::String("Val1".to_owned())),
-        //         ("v".to_owned(), Value::Union(Box::new(Value::Array(vec![Value::Float(1.0), Value::Float(2.0)]))))
-        //     ]))
-        // ]);
+        let expected = Value::Record(vec![
+            ("a".to_owned(), Value::Record(vec![
+                ("t".to_owned(), Value::String("Val1".to_owned())),
+                ("v".to_owned(), Value::Array(vec![Value::Float(1.0), Value::Float(2.0)]))
+            ]))
+        ]);
 
-        // assert_eq!(to_value(test).unwrap(), expected, "error serializing tuple adjacent enum");
+        assert_eq!(to_value(test).unwrap(), expected, "error serializing tuple adjacent enum");
 
-        // let test = TestTupleUntaggedEnum {
-        //     a: TupleUntaggedEnum::Val1(1.0, 2.0),
-        // };
+        let test = TestTupleUntaggedEnum {
+            a: TupleUntaggedEnum::Val1(1.0, 2.0),
+        };
 
-        // let expected = Value::Record(vec![
-        //     ("a".to_owned(), Value::Union(Box::new(Value::Array(vec![Value::Float(1.0), Value::Float(2.0)]))))
-        // ]);
+        let expected = Value::Record(vec![
+            ("a".to_owned(), Value::Array(vec![Value::Float(1.0), Value::Float(2.0)]))
+        ]);
 
-        // assert_eq!(to_value(test).unwrap(), expected, "error serializing tuple untagged enum");
+        assert_eq!(to_value(test).unwrap(), expected, "error serializing tuple untagged enum");
     }
 }


### PR DESCRIPTION
Hello,

Currently, it is not possible to have enums beyond the unit in this library. This is an attempt to support enums.

Let me know if there are adjustments would you like to be done.

## Implementation

There are four types of enums:
```rust
enum Unit {
    Imperial,
    Metric,
}

enum Value {
    Bool(bool),
    Float(f32),
}

enum Tuples {
    Coord2(f32, f32)
    Mixed3(f32, f32, i32)
}

enum Structs {
    Coord2 { x: f32, y: f32 }
    Coord3 { x: f32, y: f32 }
}
```

Here are the conversions that will be applied:

Unit
```json
{ "type": "enum", "name": "Unit", "symbols": ["Imperial", "Metric"] }
```

Value
```json
{ "name": "some_value", "type": {
    "type": "record",
    "name": "Value",
    "fields": [
        { "name": "type", "type": "enum", "symbols": ["Bool", "Float"] },
        { "name": "value", "type": ["boolean", "float"] }
    ]}
} 
```
Tuples
```json
{ "name": "some_tuple", "type": {
    "type": "record",
    "name": "Tuples",
    "fields": [
        { "name": "type", "type": "enum", "symbols": ["Coord2", "Mixed3"] },
        { "name": "value", "type": [
            { "type": "array", "items": ["float"] },
            { "type": "array", "items": ["int", "float"] }
        ]}        
    ]
}
```

Structs
```json
{ "name": "some_struct", "type": {
    "type": "record",
    "name": "Structs",
    "fields": [
        {"name": "type", "type": "enum", "symbols": ["Coord2", "Coord3"] },
        {"name": "value", "type": [
            { "name": "Coord2", "fields": [
                { "name": "x", "type": "float" },
                { "name": "y", "type": "float" }
            ]},
            { "name": "Coord3", "fields": [
                { "name": "x", "type": "float" },
                { "name": "y", "type": "float" },
                { "name": "z", "type": "float" }
            ]}
        ]}
    ]}
}
```

## Some additional information

1. I have taken the liberty of adding some unit tests in order to make sure that the implementation was 
   respected.
2. I removed the mut from the trait implementation of the Deserializer, it was not needed anywhere.
   Let me know if there is a need for it.

## Limitations

1. Internal, adjacent and untagged enums are not supported. I did not figure out how to create those. 
   I kept the serialization variants, but they are bogus. The Unit enums still works but they are
   serialized as string.
2. The "type" and "value" field names are hardcoded. Without fixing point 1, I don't know how 
   it should be done.
2. The library does not yet support schemas with more than one named type within a single union.
   So it is not feasible to create a schema of the "Tuples" and "Structs" example as they are.