### PR TITLE
Add edition declaration to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "Library for working with Apache Avro in Rust"
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/flavray/avro-rs"
+edition = "2018"
 
 [features]
 snappy = ["byteorder", "crc", "snap"]


### PR DESCRIPTION
Commit 35d2108 converted many source files to use Rust 2018
features (e.g., `use crate`).  These changes make avro-rs impossible
to build with older versions of the compiler.

    ~/src/avro-rs$ rustc --version
    rustc 1.29.2 (17a9dc751 2018-10-05)

    ~/src/avro-rs$ cargo check
        Checking avro-rs v0.6.4 (file:///home/vincent.foley/src/avro-rs)
    error[E0658]: `crate` in paths is experimental (see issue #45477)
      --> src/codec.rs:12:5
       |
    12 | use crate::types::{ToAvro, Value};
       |     ^^^^^

    error[E0658]: `crate` in paths is experimental (see issue #45477)
      --> src/codec.rs:13:5
       |
    13 | use crate::util::DecodeError;
       |     ^^^^^

    [Many more errors]

    error: aborting due to 33 previous errors

    For more information about this error, try `rustc --explain E0658`.
    error: Could not compile `avro-rs`.

    To learn more, run the command again with --verbose.

This commit adds an explicit declaration in Cargo.toml that Rust 2018
is needed to build avro-rs.  The build still fails with older versions
of the compiler, but at the reason is clearer.

    ~/src/avro-rs$ rustc --version
    rustc 1.29.2 (17a9dc751 2018-10-05)

    ~/src/avro-rs$ cargo check
    error: failed to parse manifest at `/home/vincent.foley/src/avro-rs/Cargo.toml`

    Caused by:
      editions are unstable

    Caused by:
      feature `edition` is required

    this Cargo does not support nightly features, but if you
    switch to nightly channel you can add
    `cargo-features = ["edition"]` to enable this feature