### PR TITLE
Support unions of named types

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -9,6 +9,7 @@ use byteorder;
 #[cfg(feature = "snappy")]
 use crc;
 
+use crate::schema::{SchemaKind, UnionRef};
 use crate::types::{ToAvro, Value};
 use crate::util::DecodeError;
 
@@ -39,6 +40,10 @@ impl ToAvro for Codec {
             }.to_owned()
                 .into_bytes(),
         )
+    }
+
+    fn union_ref(&self) -> UnionRef {
+        UnionRef::primitive(SchemaKind::Bytes)
     }
 }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -172,8 +172,8 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         V: Visitor<'de>,
     {
         match *self.input {
-            Value::Union(ref inner) if inner.as_ref() == &Value::Null => visitor.visit_none(),
-            Value::Union(ref inner) => visitor.visit_some(&mut Deserializer::new(inner)),
+            Value::Union(_, ref inner) if inner.as_ref() == &Value::Null => visitor.visit_none(),
+            Value::Union(_, ref inner) => visitor.visit_some(&mut Deserializer::new(inner)),
             _ => Err(Error::custom("not a union")),
         }
     }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -54,12 +54,12 @@ pub fn encode_ref(value: &Value, schema: &Schema, buffer: &mut Vec<u8>) {
         },
         Value::Fixed(_, bytes) => buffer.extend(bytes),
         Value::Enum(i, _) => encode_int(*i, buffer),
-        Value::Union(item) => {
+        Value::Union(union_ref, item) => {
             if let Schema::Union(ref inner) = *schema {
                 // Find the schema that is matched here. Due to validation, this should always
                 // return a value.
                 let (idx, inner_schema) = inner
-                    .find_schema(item)
+                    .find_ref(union_ref)
                     .expect("Invalid Union validation occurred");
                 encode_long(idx as i64, buffer);
                 encode_ref(&*item, inner_schema, buffer);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,7 +528,7 @@ pub mod types;
 pub use crate::codec::Codec;
 pub use crate::de::from_value;
 pub use crate::reader::{from_avro_datum, Reader};
-pub use crate::schema::{ParseSchemaError, Schema};
+pub use crate::schema::{ParseSchemaError, Schema, UnionRef};
 pub use crate::ser::to_value;
 pub use crate::types::SchemaResolutionError;
 pub use crate::util::{max_allocation_bytes, DecodeError};

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -290,6 +290,7 @@ mod tests {
     use std::io::Cursor;
     use crate::types::{Record, ToAvro};
     use crate::Reader;
+    use crate::schema::{SchemaKind, UnionRef};
 
     static SCHEMA: &'static str = r#"
             {
@@ -344,7 +345,7 @@ mod tests {
 
         assert_eq!(
             from_avro_datum(&schema, &mut encoded, None).unwrap(),
-            Value::Union(Box::new(Value::Long(0)))
+            Value::Union(UnionRef::primitive(SchemaKind::Long), Box::new(Value::Long(0)))
         );
     }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -349,6 +349,7 @@ mod tests {
     use super::*;
     use crate::types::Record;
     use crate::util::zig_i64;
+    use crate::schema::{SchemaKind, UnionRef};
 
     static SCHEMA: &'static str = r#"
             {
@@ -382,7 +383,10 @@ mod tests {
     #[test]
     fn test_union() {
         let schema = Schema::parse_str(UNION_SCHEMA).unwrap();
-        let union = Value::Union(Box::new(Value::Long(3)));
+        let union = Value::Union(
+            UnionRef::primitive(SchemaKind::Long),
+            Box::new(Value::Long(3))
+        );
 
         let mut expected = Vec::new();
         zig_i64(1, &mut expected);

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::io::Cursor;
 
 use avro_rs::types::{ToAvro, Value};
-use avro_rs::{from_avro_datum, to_avro_datum, Schema};
+use avro_rs::{from_avro_datum, to_avro_datum, Schema, UnionRef};
 
 // See https://github.com/apache/avro/blob/5af5e399/lang/py/test/test_io.py#L28
 lazy_static! {
@@ -46,7 +46,7 @@ lazy_static! {
         }),
         (
             r#"["string", "null", "long"]"#,
-            Value::Union(Box::new(Value::Null))
+            Value::Union(UnionRef::from_value(&Value::Null), Box::new(Value::Null))
         ),
         (
             r#"{"type": "record", "name": "Test", "fields": [{"name": "f", "type": "long"}]}"#,


### PR DESCRIPTION
This builds on the work in #48 to also support unions of named types.

Instead of tracking the `SchemaKind` of the variants, we keep track of the full name. This allows a union to have multiple records as variants now. The interface is a little weird to avoid leaking `SchemaKind`, but if we think it is reasonable to make that public I can rework it a bit to be a little more ergonomic.