### PR TITLE
Support for Union-Types (Serde, Schemas, Avro-Values)

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -172,8 +172,15 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         V: Visitor<'de>,
     {
         match *self.input {
-            Value::Union(ref inner) if inner.as_ref() == &Value::Null => visitor.visit_none(),
-            Value::Union(ref inner) => visitor.visit_some(&mut Deserializer::new(inner)),
+            /*
+            * https://avro.apache.org/docs/current/spec.html#Unions
+            * | Thus, for unions containing "null", the "null" is usually listed first, since the default value of such unions is typically null
+            * 
+            * Although that is not a guarantee (that the schema will be defined as ["null", {"type": ...}]: null-first), 
+            *  this can be used as a guideline to choose variant-index=0 for the None value.
+            */
+            Value::Union(0, ref inner) if inner.as_ref() == &Value::Null => visitor.visit_none(),
+            Value::Union(1, ref inner) => visitor.visit_some(&mut Deserializer::new(inner)),
             _ => Err(Error::custom("not a union")),
         }
     }

--- a/src/de.rs
+++ b/src/de.rs
@@ -52,6 +52,11 @@ struct StructDeserializer<'de> {
     value: Option<&'de Value>,
 }
 
+struct EnumDeserializer<'de> {
+    variant_name: &'static str,
+    variant_value: &'de Value,
+}
+
 impl<'de> Deserializer<'de> {
     pub fn new(input: &'de Value) -> Self {
         Deserializer { input }
@@ -85,6 +90,306 @@ impl<'de> StructDeserializer<'de> {
         }
     }
 }
+
+impl<'de> EnumDeserializer<'de> {
+    pub fn new(variant_name: &'static str, variant_value: &'de Value) -> Self {
+        EnumDeserializer {
+            variant_name,
+            variant_value, 
+        }
+    }
+}
+
+impl<'de> de::Deserializer<'de> for &mut EnumDeserializer<'de> {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_bool<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_i8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_i16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_i32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+        
+    fn deserialize_i64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_u8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_u16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_u32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_u64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_f32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_f64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_str<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_string<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+    
+    fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_unit<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_unit_struct<V>(
+        self,
+        _name: &'static str,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_seq<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_tuple<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_tuple_struct<V>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_map<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_enum<V>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+
+    fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        visitor.visit_str(self.variant_name)
+    }
+
+    fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        unreachable!()
+    }
+}
+
+impl<'de> de::EnumAccess<'de> for EnumDeserializer<'de> {
+    type Error = Error;
+    type Variant = Self;
+
+    fn variant_seed<V>(mut self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
+    where
+        V: DeserializeSeed<'de>
+    {
+
+        let value = seed.deserialize(&mut self)?;
+        
+        Ok((value, self))
+    }
+}
+
+impl<'de> de::VariantAccess<'de>  for EnumDeserializer<'de> {
+    type Error = Error;
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T>(self, _seed: T) -> Result<T::Value, Self::Error>
+    where
+        T: DeserializeSeed<'de>
+    {
+        unreachable!()
+    }
+    
+    fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        match *self.variant_value {
+            Value::Array(ref fields) =>
+                visitor.visit_seq(SeqDeserializer::new(fields.as_ref())),
+
+            _ =>
+                Err(Error::custom("tuple_variant: not an array"))
+        }
+    }
+    
+    fn struct_variant<V>(
+        self,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>
+    {
+        match *self.variant_value {
+            Value::Record(ref fields) =>
+                visitor.visit_map(StructDeserializer::new(fields.as_ref())),
+
+            _ =>
+                Err(Error::custom("struct_variant: not a record"))?,
+        }        
+    }
+}
+
+
 
 impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     type Error = Error;
@@ -197,7 +502,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
     fn deserialize_unit_struct<V>(
         self,
-        _: &'static str,
+        _name: &'static str,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
@@ -208,7 +513,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
     fn deserialize_newtype_struct<V>(
         self,
-        _: &'static str,
+        _name: &'static str,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
@@ -227,7 +532,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
         }
     }
 
-    fn deserialize_tuple<V>(self, _: usize, visitor: V) -> Result<V::Value, Self::Error>
+    fn deserialize_tuple<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
@@ -236,8 +541,8 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
     fn deserialize_tuple_struct<V>(
         self,
-        _: &'static str,
-        _: usize,
+        _name: &'static str,
+        _len: usize,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
@@ -258,8 +563,8 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
     fn deserialize_struct<V>(
         self,
-        _: &'static str,
-        _: &'static [&'static str],
+        _name: &'static str,
+        _fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
@@ -273,16 +578,20 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
 
     fn deserialize_enum<V>(
         self,
-        _: &'static str,
-        _variants: &'static [&'static str],
-        _visitor: V,
+        _name: &'static str,
+        variants: &'static [&'static str],
+        visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
         match *self.input {
-            // &Value::Enum(i) => ,  TODO
-            _ => Err(Error::custom("not an enum")),
+            Value::Union(ref variant_index, ref variant_value) => {
+                let variant_name = variants[*variant_index];
+                visitor.visit_enum(EnumDeserializer::new(variant_name, variant_value))
+            },
+            _ => 
+                Err(Error::custom("not an enum")),
         }
     }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -100,7 +100,7 @@ impl<'de> EnumDeserializer<'de> {
     pub fn new(variant_name: &'static str, variant_value: &'de Value) -> Self {
         EnumDeserializer {
             variant_name,
-            variant_value, 
+            variant_value,
         }
     }
 }
@@ -110,133 +110,133 @@ impl<'de> de::Deserializer<'de> for &mut EnumDeserializer<'de> {
 
     fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_bool<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_i8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_i16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_i32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
-        
+
     fn deserialize_i64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_u8<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_u16<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_u32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_u64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_f32<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_f64<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_char<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_str<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_string<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
-    
+
     fn deserialize_bytes<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_byte_buf<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_option<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_unit<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
@@ -247,7 +247,7 @@ impl<'de> de::Deserializer<'de> for &mut EnumDeserializer<'de> {
         _visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
@@ -258,21 +258,21 @@ impl<'de> de::Deserializer<'de> for &mut EnumDeserializer<'de> {
         _visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_seq<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_tuple<V>(self, _len: usize, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
@@ -284,14 +284,14 @@ impl<'de> de::Deserializer<'de> for &mut EnumDeserializer<'de> {
         _visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_map<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
@@ -303,7 +303,7 @@ impl<'de> de::Deserializer<'de> for &mut EnumDeserializer<'de> {
         _visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
@@ -315,21 +315,21 @@ impl<'de> de::Deserializer<'de> for &mut EnumDeserializer<'de> {
         _visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
 
     fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         visitor.visit_str(self.variant_name)
     }
 
     fn deserialize_ignored_any<V>(self, _visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         unreachable!()
     }
@@ -341,16 +341,15 @@ impl<'de> de::EnumAccess<'de> for EnumDeserializer<'de> {
 
     fn variant_seed<V>(mut self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
     where
-        V: DeserializeSeed<'de>
+        V: DeserializeSeed<'de>,
     {
-
         let value = seed.deserialize(&mut self)?;
-        
+
         Ok((value, self))
     }
 }
 
-impl<'de> de::VariantAccess<'de>  for EnumDeserializer<'de> {
+impl<'de> de::VariantAccess<'de> for EnumDeserializer<'de> {
     type Error = Error;
     fn unit_variant(self) -> Result<(), Self::Error> {
         Ok(())
@@ -358,43 +357,39 @@ impl<'de> de::VariantAccess<'de>  for EnumDeserializer<'de> {
 
     fn newtype_variant_seed<T>(self, _seed: T) -> Result<T::Value, Self::Error>
     where
-        T: DeserializeSeed<'de>
+        T: DeserializeSeed<'de>,
     {
         unreachable!()
     }
-    
+
     fn tuple_variant<V>(self, _len: usize, visitor: V) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         match *self.variant_value {
-            Value::Array(ref fields) =>
-                visitor.visit_seq(SeqDeserializer::new(fields.as_ref())),
+            Value::Array(ref fields) => visitor.visit_seq(SeqDeserializer::new(fields.as_ref())),
 
-            _ =>
-                Err(Error::custom("tuple_variant: not an array"))
+            _ => Err(Error::custom("tuple_variant: not an array")),
         }
     }
-    
+
     fn struct_variant<V>(
         self,
         _fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
-        V: Visitor<'de>
+        V: Visitor<'de>,
     {
         match *self.variant_value {
-            Value::Record(ref fields) =>
-                visitor.visit_map(StructDeserializer::new(fields.as_ref())),
+            Value::Record(ref fields) => {
+                visitor.visit_map(StructDeserializer::new(fields.as_ref()))
+            }
 
-            _ =>
-                Err(Error::custom("struct_variant: not a record"))?,
-        }        
+            _ => Err(Error::custom("struct_variant: not a record"))?,
+        }
     }
 }
-
-
 
 impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     type Error = Error;
@@ -483,12 +478,12 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         match *self.input {
             /*
-            * https://avro.apache.org/docs/current/spec.html#Unions
-            * | Thus, for unions containing "null", the "null" is usually listed first, since the default value of such unions is typically null
-            * 
-            * Although that is not a guarantee (that the schema will be defined as ["null", {"type": ...}]: null-first), 
-            *  this can be used as a guideline to choose variant-index=0 for the None value.
-            */
+             * https://avro.apache.org/docs/current/spec.html#Unions
+             * | Thus, for unions containing "null", the "null" is usually listed first, since the default value of such unions is typically null
+             *
+             * Although that is not a guarantee (that the schema will be defined as ["null", {"type": ...}]: null-first),
+             *  this can be used as a guideline to choose variant-index=0 for the None value.
+             */
             Value::Union(0, ref inner) if inner.as_ref() == &Value::Null => visitor.visit_none(),
             Value::Union(1, ref inner) => visitor.visit_some(&mut Deserializer::new(inner)),
             _ => Err(Error::custom("not a union")),
@@ -594,9 +589,8 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             Value::Union(ref variant_index, ref variant_value) => {
                 let variant_name = variants[*variant_index];
                 visitor.visit_enum(EnumDeserializer::new(variant_name, variant_value))
-            },
-            _ => 
-                Err(Error::custom("not an enum")),
+            }
+            _ => Err(Error::custom("not an enum")),
         }
     }
 

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -119,10 +119,10 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
             Ok(Value::Map(items))
         },
         Schema::Union(ref inner) => {
-            let index = zag_i64(reader)?;
+            let index = zag_i64(reader)? as usize;
             let variants = inner.variants();
             match variants.get(index as usize) {
-                Some(variant) => decode(variant, reader).map(|x| Value::Union(Box::new(x))),
+                Some(variant) => decode(variant, reader).map(|x| Value::Union(index, Box::new(x))),
                 None => Err(DecodeError::new("Union index out of bounds").into()),
             }
         },

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -54,14 +54,13 @@ pub fn encode_ref(value: &Value, schema: &Schema, buffer: &mut Vec<u8>) {
         },
         Value::Fixed(_, bytes) => buffer.extend(bytes),
         Value::Enum(i, _) => encode_int(*i, buffer),
-        Value::Union(item) => {
+        Value::Union(idx, item) => {
             if let Schema::Union(ref inner) = *schema {
-                // Find the schema that is matched here. Due to validation, this should always
-                // return a value.
-                let (idx, inner_schema) = inner
-                    .find_schema(item)
-                    .expect("Invalid Union validation occurred");
-                encode_long(idx as i64, buffer);
+                let variant_idx = *idx;
+                let inner_schema = inner
+                    .variant_schema(variant_idx)
+                    .expect(format!("Invalid variant index: {:?}", variant_idx).as_ref());
+                encode_long(variant_idx as i64, buffer);
                 encode_ref(&*item, inner_schema, buffer);
             }
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -521,6 +521,7 @@ mod reader;
 mod ser;
 mod util;
 mod writer;
+mod schema_resolution;
 
 pub mod schema;
 pub mod types;
@@ -530,7 +531,8 @@ pub use crate::de::from_value;
 pub use crate::reader::{from_avro_datum, Reader};
 pub use crate::schema::{ParseSchemaError, Schema};
 pub use crate::ser::to_value;
-pub use crate::types::SchemaResolutionError;
+pub use crate::schema_resolution::Resolution as SchemaResolution;
+pub use crate::schema_resolution::ResolutionError as SchemaResolutionError;
 pub use crate::util::{max_allocation_bytes, DecodeError};
 pub use crate::writer::{to_avro_datum, ValidationError, Writer};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,7 +465,7 @@
 //! }
 //! ```
 
-#[macro_use] 
+#[macro_use]
 extern crate failure;
 
 mod codec;
@@ -473,10 +473,10 @@ mod de;
 mod decode;
 mod encode;
 mod reader;
+mod schema_resolution;
 mod ser;
 mod util;
 mod writer;
-mod schema_resolution;
 
 pub mod schema;
 pub mod types;
@@ -485,9 +485,9 @@ pub use crate::codec::Codec;
 pub use crate::de::from_value;
 pub use crate::reader::{from_avro_datum, Reader};
 pub use crate::schema::{ParseSchemaError, Schema};
-pub use crate::ser::to_value;
 pub use crate::schema_resolution::Resolution as SchemaResolution;
 pub use crate::schema_resolution::ResolutionError as SchemaResolutionError;
+pub use crate::ser::to_value;
 pub use crate::util::{max_allocation_bytes, DecodeError};
 pub use crate::writer::{to_avro_datum, ValidationError, Writer};
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -344,7 +344,7 @@ mod tests {
 
         assert_eq!(
             from_avro_datum(&schema, &mut encoded, None).unwrap(),
-            Value::Union(Box::new(Value::Long(0)))
+            Value::Union(1, Box::new(Value::Long(0)))
         );
     }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -279,7 +279,7 @@ pub fn from_avro_datum<R: Read>(
 ) -> Result<Value, Error> {
     let value = decode(writer_schema, reader)?;
     match reader_schema {
-        Some(ref schema) => value.resolve(schema),
+        Some(ref reader_schema) => value.resolve(writer_schema, reader_schema),
         None => Ok(value),
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -323,7 +323,7 @@ pub struct UnionSchema {
 }
 
 impl UnionSchema {
-    pub(crate) fn new(schemas: Vec<Schema>) -> Result<Self, Error> {
+    pub fn new(schemas: Vec<Schema>) -> Result<Self, Error> {
         let mut prim_index = HashSet::<SchemaKind>::new();
         let mut record_index = HashSet::<String>::new();
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -329,31 +329,31 @@ impl UnionSchema {
 
         for (variant_index, schema) in schemas.iter().enumerate() {
             match schema {
-                Schema::Union(_) =>
-                    Err(ParseSchemaError::new(
-                        format!("Unions may not directly contain a union (variant-index: {})", variant_index),
-                    ))?,
-                Schema::Record { name, .. } => 
+                Schema::Union(_) => Err(ParseSchemaError::new(format!(
+                    "Unions may not directly contain a union (variant-index: {})",
+                    variant_index
+                )))?,
+                Schema::Record { name, .. } => {
                     if !record_index.insert(name.fullname(None).clone()) {
                         Err(ParseSchemaError::new(
                             format!("Union cannot have several record-variants with the same record-name (variant-index: {})", variant_index),
                         ))?
-                    },
-                
+                    }
+                }
+
                 primitive => {
                     let schema_kind = SchemaKind::from(primitive);
                     if !prim_index.insert(schema_kind) {
-                        Err(ParseSchemaError::new(
-                            format!("Unions cannot contain duplicate primitive types(variant-index: {})", variant_index),
-                        ))?
+                        Err(ParseSchemaError::new(format!(
+                            "Unions cannot contain duplicate primitive types(variant-index: {})",
+                            variant_index
+                        )))?
                     }
-                },
+                }
             }
         }
 
-        Ok(UnionSchema {
-            schemas,
-        })
+        Ok(UnionSchema { schemas })
     }
 
     /// Returns a slice to all variants of this schema.

--- a/src/schema_resolution.rs
+++ b/src/schema_resolution.rs
@@ -1,19 +1,21 @@
-
 use std::collections::HashMap;
 
-use crate::Schema;
-use crate::types::Value;
 use crate::schema::Name as RecordName;
-use serde_json::Value as JsonValue;
 use crate::schema::RecordField;
 use crate::types::ToAvro;
+use crate::types::Value;
+use crate::Schema;
+use serde_json::Value as JsonValue;
 
 #[derive(Fail, Debug, Clone, PartialEq)]
 pub enum ResolutionError {
     #[fail(display = "ResolutionError::BytesToStringUtf8Error")]
     BytesToStringUtf8Error,
-    
-    #[fail(display = "ResolutionError::IncompatibleSchema: writer={:?}, reader={:?}", _0, _1)]
+
+    #[fail(
+        display = "ResolutionError::IncompatibleSchema: writer={:?}, reader={:?}",
+        _0, _1
+    )]
     IncompatibleSchema(Schema, Schema),
 
     #[fail(display = "ResolutionError::IncompatibleData: data={:?}", _0)]
@@ -22,7 +24,10 @@ pub enum ResolutionError {
     #[fail(display = "ResolutionError::UnexpectedVariant: variant={}", _0)]
     UnexpectedVariant(usize),
 
-    #[fail(display = "ResolutionError::RecordFieldMissing: record={:?}, field={}", _0, _1)]
+    #[fail(
+        display = "ResolutionError::RecordFieldMissing: record={:?}, field={}",
+        _0, _1
+    )]
     RecordFieldMissing(RecordName, usize),
 
     #[fail(display = "ResolutionError::RecordFieldValueMissing: {}", _0)]
@@ -48,14 +53,13 @@ pub enum RecordFieldResolution {
         r_pos: usize,
         name: String,
         value: Value,
-    }
+    },
 }
 // pub struct RecordFieldResolution {
 //     from_pos: usize,
 //     to_pos: usize,
 //     value: Resolution,
 // }
-
 
 #[derive(Debug, Clone)]
 pub enum Resolution {
@@ -88,7 +92,10 @@ impl Resolution {
     //     Resolution::Identity
     // }
 
-    pub fn new(writer_schema: &Schema, reader_schema: &Schema) -> Result<Resolution, ResolutionError> {
+    pub fn new(
+        writer_schema: &Schema,
+        reader_schema: &Schema,
+    ) -> Result<Resolution, ResolutionError> {
         if writer_schema == reader_schema {
             Ok(Resolution::Identity)
         } else {
@@ -106,24 +113,23 @@ impl Resolution {
                 // (Schema::String, Schema::String) => Ok(Resolution::Identity),
 
                 // * both schemas are arrays whose item types match
-                (Schema::Array(ref writer_inner), Schema::Array(ref reader_inner)) => 
-                    Self::new(writer_inner, reader_inner)
-                        .map(|inner_resolution| {
-                            match inner_resolution {
-                                Resolution::Identity => Resolution::Identity,
-                                promotion => Resolution::Array(Box::new(promotion))
-                            }
-                        }),
+                (Schema::Array(ref writer_inner), Schema::Array(ref reader_inner)) => {
+                    Self::new(writer_inner, reader_inner).map(|inner_resolution| {
+                        match inner_resolution {
+                            Resolution::Identity => Resolution::Identity,
+                            promotion => Resolution::Array(Box::new(promotion)),
+                        }
+                    })
+                }
                 // * both schemas are maps whose value types match
-                (Schema::Map(ref writer_inner), Schema::Map(ref reader_inner)) => 
-                    Self::new(writer_inner, reader_inner)
-                        .map(|inner_resolution| {
-                            match inner_resolution {
-                                Resolution::Identity => Resolution::Identity,
-                                promotion => Resolution::Map(Box::new(promotion))
-                            }
-                        }),
-                
+                (Schema::Map(ref writer_inner), Schema::Map(ref reader_inner)) => {
+                    Self::new(writer_inner, reader_inner).map(|inner_resolution| {
+                        match inner_resolution {
+                            Resolution::Identity => Resolution::Identity,
+                            promotion => Resolution::Map(Box::new(promotion)),
+                        }
+                    })
+                }
 
                 // ... the writer's schema may be promoted to the reader's as follows:
                 // * bytes is promotable to string
@@ -144,130 +150,161 @@ impl Resolution {
                  * if both are enums:
                  *  if the writer's symbol is not present in the reader's enum, then an error is signalled.
                  */
-                (Schema::Enum { name: w_name, symbols: w_symbols, .. }, Schema::Enum { name: r_name, symbols: r_symbols, .. }) if w_name == r_name => {
-                    let r_symbol_map =
-                        r_symbols.iter().enumerate()
-                            .map(|(idx, symbol)| (symbol, idx as i32))
-                            .collect::<HashMap<_, _>>();
+                (
+                    Schema::Enum {
+                        name: w_name,
+                        symbols: w_symbols,
+                        ..
+                    },
+                    Schema::Enum {
+                        name: r_name,
+                        symbols: r_symbols,
+                        ..
+                    },
+                ) if w_name == r_name => {
+                    let r_symbol_map = r_symbols
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, symbol)| (symbol, idx as i32))
+                        .collect::<HashMap<_, _>>();
 
-                    let translation_map =
-                        w_symbols.iter().enumerate()
-                            .filter_map(|(w_idx, symbol)| 
-                                r_symbol_map
-                                    .get(&symbol)
-                                    .map(|r_idx| (w_idx as i32, (*r_idx, symbol.clone()))) )
-                            .collect::<HashMap<i32, (i32, String)>>();
+                    let translation_map = w_symbols
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(w_idx, symbol)| {
+                            r_symbol_map
+                                .get(&symbol)
+                                .map(|r_idx| (w_idx as i32, (*r_idx, symbol.clone())))
+                        })
+                        .collect::<HashMap<i32, (i32, String)>>();
 
                     Ok(Resolution::EnumChoice(translation_map))
-                },
+                }
 
                 // * if both are unions:
                 //   The first schema in the reader's union that matches the selected writer's union schema is recursively resolved against it. if none match, an error is signalled.
                 (Schema::Union(w_union_schema), r_schema @ Schema::Union(_)) => {
                     Ok(Resolution::UnionChoice(
-                        w_union_schema.variants().iter()
-                            .map(|w_variant| 
-                                match Self::new(w_variant, r_schema) {
-                                    Ok(resolution) => resolution,
-                                    Err(reason) => Resolution::Failure(reason),
-                                })
-                            .collect::<Vec<_>>()))
-                },
+                        w_union_schema
+                            .variants()
+                            .iter()
+                            .map(|w_variant| match Self::new(w_variant, r_schema) {
+                                Ok(resolution) => resolution,
+                                Err(reason) => Resolution::Failure(reason),
+                            })
+                            .collect::<Vec<_>>(),
+                    ))
+                }
 
                 // * if reader's is a union, but writer's is not
                 //   The first schema in the reader's union that matches the writer's schema is recursively resolved against it. If none match, an error is signalled.
                 (w_non_union, Schema::Union(r_union_schema)) => {
                     let r_variants = r_union_schema.variants();
-                    r_variants.iter()
+                    r_variants
+                        .iter()
                         .enumerate()
-                        .find_map(|(r_idx, r_variant)| 
-                            Self::new(w_non_union, r_variant)
-                                .ok()
-                                .map(|resolution| Resolution::UnionVariant(r_idx, Box::new(resolution)))
-                        )
+                        .find_map(|(r_idx, r_variant)| {
+                            Self::new(w_non_union, r_variant).ok().map(|resolution| {
+                                Resolution::UnionVariant(r_idx, Box::new(resolution))
+                            })
+                        })
                         .map(|resolution| Ok(resolution))
-                        .unwrap_or_else(|| 
+                        .unwrap_or_else(|| {
                             Err(ResolutionError::IncompatibleSchema(
-                                w_non_union.clone(), 
-                                Schema::Union(r_union_schema.clone()))))
-                },
+                                w_non_union.clone(),
+                                Schema::Union(r_union_schema.clone()),
+                            ))
+                        })
+                }
 
                 // * if writer's is a union, but reader's is not
                 //   If the reader's schema matches the selected writer's schema, it is recursively resolved against it. If they do not match, an error is signalled.
-                (Schema::Union(w_union_schema), r_non_union) =>
-                    Ok(
-                        Resolution::UnionChoice(
-                            w_union_schema.variants().iter()
-                                .map(|w_variant| 
-                                    match Self::new(w_variant, r_non_union) {
-                                        Ok(resolution) => resolution,
-                                        Err(reason) => Resolution::Failure(reason),
-                                    })
-                                .collect::<Vec<_>>())),
+                (Schema::Union(w_union_schema), r_non_union) => Ok(Resolution::UnionChoice(
+                    w_union_schema
+                        .variants()
+                        .iter()
+                        .map(|w_variant| match Self::new(w_variant, r_non_union) {
+                            Ok(resolution) => resolution,
+                            Err(reason) => Resolution::Failure(reason),
+                        })
+                        .collect::<Vec<_>>(),
+                )),
 
-                (Schema::Record { name: w_name, fields: w_fields, lookup: w_lookup, .. }, Schema::Record { name: r_name, fields: r_fields, .. }) 
-                if r_name == w_name => {
+                (
+                    Schema::Record {
+                        name: w_name,
+                        fields: w_fields,
+                        lookup: w_lookup,
+                        ..
+                    },
+                    Schema::Record {
+                        name: r_name,
+                        fields: r_fields,
+                        ..
+                    },
+                ) if r_name == w_name => {
                     /*
-                    * ... if both are records:
-                    *   - the ordering of fields may be different: fields are matched by name.
-                    *   - schemas for fields with the same name in both records are resolved recursively.
-                    *   - if the writer's record contains a field with a name not present in the reader's record, the writer's value for that field is ignored.
-                    *   - if the reader's record schema has a field that contains a default value, and writer's schema does not have a field with the same name, then the reader should use the default value from its field.
-                    *   - if the reader's record schema has a field with no default value, and writer's schema does not have a field with the same name, an error is signalled.
-                    */
+                     * ... if both are records:
+                     *   - the ordering of fields may be different: fields are matched by name.
+                     *   - schemas for fields with the same name in both records are resolved recursively.
+                     *   - if the writer's record contains a field with a name not present in the reader's record, the writer's value for that field is ignored.
+                     *   - if the reader's record schema has a field that contains a default value, and writer's schema does not have a field with the same name, then the reader should use the default value from its field.
+                     *   - if the reader's record schema has a field with no default value, and writer's schema does not have a field with the same name, an error is signalled.
+                     */
                     r_fields
-                        .into_iter().enumerate()
+                        .into_iter()
+                        .enumerate()
                         .map(|(r_pos, r_field)| {
                             assert_eq!(r_pos, r_field.position);
-                            
+
                             let w_pos_opt: Option<&usize> = w_lookup.get(&r_field.name);
 
-                            let w_pos_and_field_opt: Option<(usize, RecordField)> = w_pos_opt
-                                .map(|w_pos| {
+                            let w_pos_and_field_opt: Option<(usize, RecordField)> =
+                                w_pos_opt.map(|w_pos| {
                                     assert_eq!(*w_pos, w_fields[*w_pos].position);
 
                                     (*w_pos, w_fields[*w_pos].clone())
                                 });
 
-                            let field_present_result_opt: Option<Result<RecordFieldResolution, ResolutionError>> =
-                                w_pos_and_field_opt
-                                    .map(|(w_pos, w_field)| {
-                                        Self::new(&w_field.schema, &r_field.schema)
-                                            .map(|resolution| {
-                                                RecordFieldResolution::Present {
-                                                    w_pos,
-                                                    r_pos,
-                                                    name: r_field.name.clone(),
-                                                    resolution,
-                                                }
-                                            })
-                                    });
+                            let field_present_result_opt: Option<
+                                Result<RecordFieldResolution, ResolutionError>,
+                            > = w_pos_and_field_opt.map(|(w_pos, w_field)| {
+                                Self::new(&w_field.schema, &r_field.schema).map(|resolution| {
+                                    RecordFieldResolution::Present {
+                                        w_pos,
+                                        r_pos,
+                                        name: r_field.name.clone(),
+                                        resolution,
+                                    }
+                                })
+                            });
 
                             let field_result: Result<RecordFieldResolution, ResolutionError> =
-                                field_present_result_opt
-                                    .unwrap_or_else(|| {
-                                        match r_field.default {
-                                            None => 
-                                                Err(ResolutionError::RecordFieldMissing(r_name.clone(), r_pos)),
-                                            Some(ref default_value_json) =>
-                                                Self::value_from_json(&r_field.schema, default_value_json)
-                                                    .map(|default_value|
-                                                        RecordFieldResolution::Absent { 
-                                                            r_pos, 
-                                                            name: r_field.name.clone(),
-                                                            value: default_value
-                                                        })
-                                        }
-                                    });
+                                field_present_result_opt.unwrap_or_else(|| match r_field.default {
+                                    None => Err(ResolutionError::RecordFieldMissing(
+                                        r_name.clone(),
+                                        r_pos,
+                                    )),
+                                    Some(ref default_value_json) => {
+                                        Self::value_from_json(&r_field.schema, default_value_json)
+                                            .map(|default_value| RecordFieldResolution::Absent {
+                                                r_pos,
+                                                name: r_field.name.clone(),
+                                                value: default_value,
+                                            })
+                                    }
+                                });
 
                             field_result
                         })
                         .collect::<Result<_, _>>()
                         .map(|field_resolutions| Resolution::Record(field_resolutions))
-                },
+                }
 
-                (writer_schema, reader_schema) => 
-                    Err(ResolutionError::IncompatibleSchema(writer_schema.clone(), reader_schema.clone())),
+                (writer_schema, reader_schema) => Err(ResolutionError::IncompatibleSchema(
+                    writer_schema.clone(),
+                    reader_schema.clone(),
+                )),
             }
         }
     }
@@ -276,12 +313,12 @@ impl Resolution {
         match (self.clone(), value) {
             (Resolution::Failure(reason), _) => Err(reason),
             (Resolution::Identity, as_is) => Ok(as_is),
-            
+
             (Resolution::IntToLong, Value::Int(v)) => Ok(Value::Long(v.into())),
-            // XXX: I feel really bad for those poor folks who will experience such "promotion" of their values. 
+            // XXX: I feel really bad for those poor folks who will experience such "promotion" of their values.
             (Resolution::IntToFloat, Value::Int(v)) => Ok(Value::Float(v as f32)), // should we check if |v| < 2^24?
             (Resolution::IntToDouble, Value::Int(v)) => Ok(Value::Double(v.into())),
-            
+
             // XXX: See above
             (Resolution::LongToFloat, Value::Long(v)) => Ok(Value::Float(v as f32)), // should we check if |v| < 2^24?
             // XXX: See above
@@ -290,64 +327,61 @@ impl Resolution {
             (Resolution::FloatToDouble, Value::Float(v)) => Ok(Value::Double(v.into())),
 
             (Resolution::StringToBytes, Value::String(v)) => Ok(Value::Bytes(v.into_bytes())),
-            (Resolution::BytesToString, Value::Bytes(v)) => Ok(Value::String(String::from_utf8(v)?)),
+            (Resolution::BytesToString, Value::Bytes(v)) => {
+                Ok(Value::String(String::from_utf8(v)?))
+            }
 
-            (Resolution::Array(inner), Value::Array(vs)) => 
-                vs.into_iter()
-                    .map(|v| inner.promote_value(v))
-                    .collect::<Result<_, _>>()
-                    .map(|vs| Value::Array(vs)),
+            (Resolution::Array(inner), Value::Array(vs)) => vs
+                .into_iter()
+                .map(|v| inner.promote_value(v))
+                .collect::<Result<_, _>>()
+                .map(|vs| Value::Array(vs)),
 
-            (Resolution::Map(inner), Value::Map(vs_map)) => 
-                vs_map
-                    .into_iter()
-                    .map(|(k, v)| inner.promote_value(v).map(|v| (k, v)))
-                    .collect::<Result<Vec<_>, _>>()
-                    .map(|pairs| pairs.into_iter().collect::<HashMap<_, _>>())
-                    .map(|vs_map| Value::Map(vs_map)),
+            (Resolution::Map(inner), Value::Map(vs_map)) => vs_map
+                .into_iter()
+                .map(|(k, v)| inner.promote_value(v).map(|v| (k, v)))
+                .collect::<Result<Vec<_>, _>>()
+                .map(|pairs| pairs.into_iter().collect::<HashMap<_, _>>())
+                .map(|vs_map| Value::Map(vs_map)),
 
             (Resolution::Record(resolutions), Value::Record(w_fields)) => {
                 let mut w_field_map = w_fields.into_iter().collect::<HashMap<_, _>>();
 
                 resolutions
                     .into_iter()
-                    .map(|field_resolution| {
-                        match field_resolution {
-                            RecordFieldResolution::Absent { name, value, .. } =>
-                                Ok((name, value)),
-                            RecordFieldResolution::Present { name, resolution, .. } => {
-                                w_field_map.remove(&name)
-                                    .ok_or(ResolutionError::RecordFieldValueMissing(name.clone()))
-                                    .and_then(|w_value| {
-                                        resolution.promote_value(w_value)
-                                    })
-                                    .map(|promoted_value| {
-                                        (name, promoted_value)
-                                    })
-                            },
-                        }
+                    .map(|field_resolution| match field_resolution {
+                        RecordFieldResolution::Absent { name, value, .. } => Ok((name, value)),
+                        RecordFieldResolution::Present {
+                            name, resolution, ..
+                        } => w_field_map
+                            .remove(&name)
+                            .ok_or(ResolutionError::RecordFieldValueMissing(name.clone()))
+                            .and_then(|w_value| resolution.promote_value(w_value))
+                            .map(|promoted_value| (name, promoted_value)),
                     })
                     .collect::<Result<Vec<(String, Value)>, ResolutionError>>()
                     .map(|fields| Value::Record(fields))
-            },
+            }
 
-            (Resolution::EnumChoice(symbols), Value::Enum(w_idx, w_symbol)) => 
-                symbols.get(&w_idx)
-                    .map(|(r_idx, r_symbol)| Ok(Value::Enum(*r_idx, r_symbol.clone())))
-                    .unwrap_or_else(|| Err(ResolutionError::IncompatibleData(Value::Enum(w_idx, w_symbol)))),
+            (Resolution::EnumChoice(symbols), Value::Enum(w_idx, w_symbol)) => symbols
+                .get(&w_idx)
+                .map(|(r_idx, r_symbol)| Ok(Value::Enum(*r_idx, r_symbol.clone())))
+                .unwrap_or_else(|| {
+                    Err(ResolutionError::IncompatibleData(Value::Enum(
+                        w_idx, w_symbol,
+                    )))
+                }),
 
-            (Resolution::UnionChoice(variants), Value::Union(idx, value)) =>
-                variants.get(idx)
-                    .map(|resolution| resolution.promote_value(*value))
-                    .unwrap_or_else(|| Err(ResolutionError::UnexpectedVariant(idx))),
+            (Resolution::UnionChoice(variants), Value::Union(idx, value)) => variants
+                .get(idx)
+                .map(|resolution| resolution.promote_value(*value))
+                .unwrap_or_else(|| Err(ResolutionError::UnexpectedVariant(idx))),
 
-            (Resolution::UnionVariant(idx, inner), value) =>
-                inner
-                    .promote_value(value)
-                    .map(|promoted_inner| Value::Union(idx, Box::new(promoted_inner))),
+            (Resolution::UnionVariant(idx, inner), value) => inner
+                .promote_value(value)
+                .map(|promoted_inner| Value::Union(idx, Box::new(promoted_inner))),
 
-            (_resolution, data) => 
-                Err(ResolutionError::IncompatibleData(data))
+            (_resolution, data) => Err(ResolutionError::IncompatibleData(data)),
         }
     }
 
@@ -358,44 +392,59 @@ impl Resolution {
         match (schema, value) {
             (Schema::Null, JsonValue::Null) => Ok(Value::Null),
             (Schema::Boolean, JsonValue::Bool(v)) => Ok(Value::Boolean(*v)),
-            (Schema::Int, JsonValue::Number(v)) if v.is_i64() => Ok(Value::Int(v.as_i64().unwrap() as i32)),
-            (Schema::Long, JsonValue::Number(v)) if v.is_i64() => Ok(Value::Long(v.as_i64().unwrap())),
-            (Schema::Float, JsonValue::Number(v)) if v.is_f64() => Ok(Value::Float(v.as_f64().unwrap() as f32)),
-            (Schema::Double, JsonValue::Number(v)) if v.is_f64() => Ok(Value::Double(v.as_f64().unwrap())),
+            (Schema::Int, JsonValue::Number(v)) if v.is_i64() => {
+                Ok(Value::Int(v.as_i64().unwrap() as i32))
+            }
+            (Schema::Long, JsonValue::Number(v)) if v.is_i64() => {
+                Ok(Value::Long(v.as_i64().unwrap()))
+            }
+            (Schema::Float, JsonValue::Number(v)) if v.is_f64() => {
+                Ok(Value::Float(v.as_f64().unwrap() as f32))
+            }
+            (Schema::Double, JsonValue::Number(v)) if v.is_f64() => {
+                Ok(Value::Double(v.as_f64().unwrap()))
+            }
             (Schema::String, JsonValue::String(v)) => Ok(Value::String(v.clone())),
             (Schema::Bytes, JsonValue::String(v)) => Ok(Value::Bytes(v.clone().into_bytes())),
-            (Schema::Array(inner), JsonValue::Array(vs)) =>
-                vs.iter()
-                    .map(|v| Self::value_from_json(inner, v))
-                    .collect::<Result<_, _>>()
-                    .map(|vs| Value::Array(vs)),
-            (Schema::Enum { symbols, .. }, JsonValue::String(v)) =>
-                symbols
-                    .iter()
-                    .enumerate()
-                    .find_map(|(idx, symbol)| 
-                        if symbol == v {
-                            Some(Ok(Value::Enum(idx as i32, symbol.clone())))
-                        } else {
-                            None
-                        }
-                    )
-                    .unwrap_or_else(|| 
-                        Err( ResolutionError::InvalidDefaultValue(JsonValue::String(v.to_owned())) )),
+            (Schema::Array(inner), JsonValue::Array(vs)) => vs
+                .iter()
+                .map(|v| Self::value_from_json(inner, v))
+                .collect::<Result<_, _>>()
+                .map(|vs| Value::Array(vs)),
+            (Schema::Enum { symbols, .. }, JsonValue::String(v)) => symbols
+                .iter()
+                .enumerate()
+                .find_map(|(idx, symbol)| {
+                    if symbol == v {
+                        Some(Ok(Value::Enum(idx as i32, symbol.clone())))
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_else(|| {
+                    Err(ResolutionError::InvalidDefaultValue(JsonValue::String(
+                        v.to_owned(),
+                    )))
+                }),
 
             (_, _) => Err(ResolutionError::InvalidDefaultValue(value.clone())),
         }
     }
 }
 
-fn resolve_and_promote_single(writer_schema: &Schema, reader_schema: &Schema, original_value: Value, expected_adjusted_value: Value) -> Result<(), ResolutionError> {
+fn resolve_and_promote_single(
+    writer_schema: &Schema,
+    reader_schema: &Schema,
+    original_value: Value,
+    expected_adjusted_value: Value,
+) -> Result<(), ResolutionError> {
     let resolution = Resolution::new(writer_schema, reader_schema)?;
     let adjusted_value = resolution.promote_value(original_value)?;
     if adjusted_value != expected_adjusted_value {
         Err(ResolutionError::Generic(
-            format!("{:?} != {:?}", adjusted_value, expected_adjusted_value).into()
+            format!("{:?} != {:?}", adjusted_value, expected_adjusted_value).into(),
         ))
-    } else { 
+    } else {
         Ok(())
     }
 }
@@ -403,43 +452,132 @@ fn resolve_and_promote_single(writer_schema: &Schema, reader_schema: &Schema, or
 #[test]
 fn test_resolve_and_promote_primitives() {
     resolve_and_promote_single(&Schema::Null, &Schema::Null, Value::Null, Value::Null).unwrap();
-    
-    resolve_and_promote_single(&Schema::Boolean, &Schema::Boolean, Value::Boolean(false), Value::Boolean(false)).unwrap();
-    resolve_and_promote_single(&Schema::Boolean, &Schema::Boolean, Value::Boolean(true), Value::Boolean(true)).unwrap();
-    
+
+    resolve_and_promote_single(
+        &Schema::Boolean,
+        &Schema::Boolean,
+        Value::Boolean(false),
+        Value::Boolean(false),
+    )
+    .unwrap();
+    resolve_and_promote_single(
+        &Schema::Boolean,
+        &Schema::Boolean,
+        Value::Boolean(true),
+        Value::Boolean(true),
+    )
+    .unwrap();
+
     resolve_and_promote_single(&Schema::Int, &Schema::Int, Value::Int(42), Value::Int(42)).unwrap();
-    resolve_and_promote_single(&Schema::Int, &Schema::Long, Value::Int(42), Value::Long(42)).unwrap();
-    resolve_and_promote_single(&Schema::Int, &Schema::Float, Value::Int(42), Value::Float(42.0)).unwrap();
-    resolve_and_promote_single(&Schema::Int, &Schema::Double, Value::Int(42), Value::Double(42.0)).unwrap();
+    resolve_and_promote_single(&Schema::Int, &Schema::Long, Value::Int(42), Value::Long(42))
+        .unwrap();
+    resolve_and_promote_single(
+        &Schema::Int,
+        &Schema::Float,
+        Value::Int(42),
+        Value::Float(42.0),
+    )
+    .unwrap();
+    resolve_and_promote_single(
+        &Schema::Int,
+        &Schema::Double,
+        Value::Int(42),
+        Value::Double(42.0),
+    )
+    .unwrap();
 
-    resolve_and_promote_single(&Schema::Long, &Schema::Long, Value::Long(42), Value::Long(42)).unwrap();
-    resolve_and_promote_single(&Schema::Long, &Schema::Float, Value::Long(42), Value::Float(42.0)).unwrap();
-    resolve_and_promote_single(&Schema::Long, &Schema::Double, Value::Long(42), Value::Double(42.0)).unwrap();
+    resolve_and_promote_single(
+        &Schema::Long,
+        &Schema::Long,
+        Value::Long(42),
+        Value::Long(42),
+    )
+    .unwrap();
+    resolve_and_promote_single(
+        &Schema::Long,
+        &Schema::Float,
+        Value::Long(42),
+        Value::Float(42.0),
+    )
+    .unwrap();
+    resolve_and_promote_single(
+        &Schema::Long,
+        &Schema::Double,
+        Value::Long(42),
+        Value::Double(42.0),
+    )
+    .unwrap();
 
-    resolve_and_promote_single(&Schema::Float, &Schema::Float, Value::Float(42.0), Value::Float(42.0)).unwrap();
-    resolve_and_promote_single(&Schema::Float, &Schema::Double, Value::Float(42.0), Value::Double(42.0)).unwrap();
+    resolve_and_promote_single(
+        &Schema::Float,
+        &Schema::Float,
+        Value::Float(42.0),
+        Value::Float(42.0),
+    )
+    .unwrap();
+    resolve_and_promote_single(
+        &Schema::Float,
+        &Schema::Double,
+        Value::Float(42.0),
+        Value::Double(42.0),
+    )
+    .unwrap();
 
-    resolve_and_promote_single(&Schema::Double, &Schema::Double, Value::Double(42.0), Value::Double(42.0)).unwrap();
+    resolve_and_promote_single(
+        &Schema::Double,
+        &Schema::Double,
+        Value::Double(42.0),
+        Value::Double(42.0),
+    )
+    .unwrap();
 
-    resolve_and_promote_single(&Schema::Bytes, &Schema::Bytes, Value::Bytes(vec![1,2,3]), Value::Bytes(vec![1,2,3])).unwrap();
-    resolve_and_promote_single(&Schema::Bytes, &Schema::String, Value::Bytes("abc".to_owned().into_bytes()), Value::String("abc".to_owned())).unwrap();
+    resolve_and_promote_single(
+        &Schema::Bytes,
+        &Schema::Bytes,
+        Value::Bytes(vec![1, 2, 3]),
+        Value::Bytes(vec![1, 2, 3]),
+    )
+    .unwrap();
+    resolve_and_promote_single(
+        &Schema::Bytes,
+        &Schema::String,
+        Value::Bytes("abc".to_owned().into_bytes()),
+        Value::String("abc".to_owned()),
+    )
+    .unwrap();
 
-    resolve_and_promote_single(&Schema::String, &Schema::String, Value::String("abc".to_owned()), Value::String("abc".to_owned())).unwrap();
-    resolve_and_promote_single(&Schema::String, &Schema::Bytes, Value::String("abc".to_owned()), Value::Bytes("abc".to_owned().into_bytes())).unwrap();
+    resolve_and_promote_single(
+        &Schema::String,
+        &Schema::String,
+        Value::String("abc".to_owned()),
+        Value::String("abc".to_owned()),
+    )
+    .unwrap();
+    resolve_and_promote_single(
+        &Schema::String,
+        &Schema::Bytes,
+        Value::String("abc".to_owned()),
+        Value::Bytes("abc".to_owned().into_bytes()),
+    )
+    .unwrap();
 }
 
 #[test]
 fn test_resolve_and_promote_arrays() {
     resolve_and_promote_single(
-        &Schema::Array(Box::new(Schema::Int)), 
         &Schema::Array(Box::new(Schema::Int)),
-        Value::Array(vec![Value::Int(1), Value::Int(2)]), 
-        Value::Array(vec![Value::Int(1), Value::Int(2)])).unwrap();
+        &Schema::Array(Box::new(Schema::Int)),
+        Value::Array(vec![Value::Int(1), Value::Int(2)]),
+        Value::Array(vec![Value::Int(1), Value::Int(2)]),
+    )
+    .unwrap();
     resolve_and_promote_single(
-        &Schema::Array(Box::new(Schema::Int)), 
+        &Schema::Array(Box::new(Schema::Int)),
         &Schema::Array(Box::new(Schema::Long)),
-        Value::Array(vec![Value::Int(1), Value::Int(2)]), 
-        Value::Array(vec![Value::Long(1), Value::Long(2)])).unwrap();
+        Value::Array(vec![Value::Int(1), Value::Int(2)]),
+        Value::Array(vec![Value::Long(1), Value::Long(2)]),
+    )
+    .unwrap();
 }
 
 #[test]
@@ -447,34 +585,51 @@ fn test_resolve_and_promote_maps() {
     resolve_and_promote_single(
         &Schema::Map(Box::new(Schema::Int)),
         &Schema::Map(Box::new(Schema::Int)),
-        Value::Map(vec![
-            ("one".to_owned(), Value::Int(1)),
-            ("two".to_owned(), Value::Int(2)),
-            ].into_iter().collect()),
-        Value::Map(vec![
-            ("one".to_owned(), Value::Int(1)),
-            ("two".to_owned(), Value::Int(2)),
-            ].into_iter().collect())
-    ).unwrap();
+        Value::Map(
+            vec![
+                ("one".to_owned(), Value::Int(1)),
+                ("two".to_owned(), Value::Int(2)),
+            ]
+            .into_iter()
+            .collect(),
+        ),
+        Value::Map(
+            vec![
+                ("one".to_owned(), Value::Int(1)),
+                ("two".to_owned(), Value::Int(2)),
+            ]
+            .into_iter()
+            .collect(),
+        ),
+    )
+    .unwrap();
     resolve_and_promote_single(
         &Schema::Map(Box::new(Schema::Int)),
         &Schema::Map(Box::new(Schema::Long)),
-        Value::Map(vec![
-            ("one".to_owned(), Value::Int(1)),
-            ("two".to_owned(), Value::Int(2)),
-            ].into_iter().collect()),
-        Value::Map(vec![
-            ("one".to_owned(), Value::Long(1)),
-            ("two".to_owned(), Value::Long(2)),
-            ].into_iter().collect())
-    ).unwrap();
-    
+        Value::Map(
+            vec![
+                ("one".to_owned(), Value::Int(1)),
+                ("two".to_owned(), Value::Int(2)),
+            ]
+            .into_iter()
+            .collect(),
+        ),
+        Value::Map(
+            vec![
+                ("one".to_owned(), Value::Long(1)),
+                ("two".to_owned(), Value::Long(2)),
+            ]
+            .into_iter()
+            .collect(),
+        ),
+    )
+    .unwrap();
 }
 
 #[test]
 fn test_resolve_and_promote_records() {
-    let w_schema = 
-        Schema::parse_str(r#"
+    let w_schema = Schema::parse_str(
+        r#"
             {
                 "type": "record",
                 "name": "r1",
@@ -483,9 +638,11 @@ fn test_resolve_and_promote_records() {
                     {"name": "a_number_obsolete", "type": "int"}
                 ]
             }
-        "#).unwrap();
-    let r_schema =
-        Schema::parse_str(r#"
+        "#,
+    )
+    .unwrap();
+    let r_schema = Schema::parse_str(
+        r#"
             {
                 "type": "record",
                 "name": "r1",
@@ -494,39 +651,35 @@ fn test_resolve_and_promote_records() {
                     {"name": "a_number_with_default", "type": "long", "default": 42}
                 ]
             }
-        "#).unwrap();
-    let w_record = 
-        Value::Record(vec![
-            ("a_number_no_default".to_owned(), Value::Int(13)),
-            ("a_number_obsolete".to_owned(), Value::Int(-1)),
-        ]);
-    let r_record = 
-        Value::Record(vec![
-            ("a_number_no_default".to_owned(), Value::Long(13)),
-            ("a_number_with_default".to_owned(), Value::Long(42)),
-        ]);
-    resolve_and_promote_single(
-        &w_schema, &w_schema,
-        w_record.clone(), w_record.clone()
-    ).unwrap();
-    resolve_and_promote_single(
-        &w_schema, &r_schema,
-        w_record.clone(), r_record.clone()
-    ).unwrap();
+        "#,
+    )
+    .unwrap();
+    let w_record = Value::Record(vec![
+        ("a_number_no_default".to_owned(), Value::Int(13)),
+        ("a_number_obsolete".to_owned(), Value::Int(-1)),
+    ]);
+    let r_record = Value::Record(vec![
+        ("a_number_no_default".to_owned(), Value::Long(13)),
+        ("a_number_with_default".to_owned(), Value::Long(42)),
+    ]);
+    resolve_and_promote_single(&w_schema, &w_schema, w_record.clone(), w_record.clone()).unwrap();
+    resolve_and_promote_single(&w_schema, &r_schema, w_record.clone(), r_record.clone()).unwrap();
 }
 
 #[test]
 fn test_resolve_and_promote_record_with_default_int() {
-    let w_schema = 
-        Schema::parse_str(r#"
+    let w_schema = Schema::parse_str(
+        r#"
             {
                 "type": "record",
                 "name": "r2",
                 "fields": []
             }
-        "#).unwrap();
-    let r_schema = 
-        Schema::parse_str(r#"
+        "#,
+    )
+    .unwrap();
+    let r_schema = Schema::parse_str(
+        r#"
             {
                 "type": "record",
                 "name": "r2",
@@ -534,27 +687,19 @@ fn test_resolve_and_promote_record_with_default_int() {
                     {"name": "a_field", "type": "int", "default": 42}
                 ]
             }
-        "#).unwrap();
-    let w_data = 
-        Value::Record(vec![]);
-    let r_data =
-        Value::Record(vec![
-            ("a_field".to_owned(), Value::Int(42)),
-        ]);
-    resolve_and_promote_single(
-        &w_schema, &w_schema,
-        w_data.clone(), w_data.clone()
-    ).unwrap();
-    resolve_and_promote_single(
-        &w_schema, &r_schema,
-        w_data.clone(), r_data.clone()
-    ).unwrap();
+        "#,
+    )
+    .unwrap();
+    let w_data = Value::Record(vec![]);
+    let r_data = Value::Record(vec![("a_field".to_owned(), Value::Int(42))]);
+    resolve_and_promote_single(&w_schema, &w_schema, w_data.clone(), w_data.clone()).unwrap();
+    resolve_and_promote_single(&w_schema, &r_schema, w_data.clone(), r_data.clone()).unwrap();
 }
 
 #[test]
 fn test_resolve_and_promote_into_union() {
-    let w_schema = 
-        Schema::parse_str(r#"
+    let w_schema = Schema::parse_str(
+        r#"
             {
                 "type": "record",
                 "name": "r2",
@@ -562,9 +707,11 @@ fn test_resolve_and_promote_into_union() {
                     {"name": "a_field", "type": "long"}
                 ]
             }
-        "#).unwrap();
-    let r_schema =
-        Schema::parse_str(r#"
+        "#,
+    )
+    .unwrap();
+    let r_schema = Schema::parse_str(
+        r#"
             [
                 {"type": "long"},
                 {
@@ -583,35 +730,26 @@ fn test_resolve_and_promote_into_union() {
                     ]
                 }
             ]
-        "#).unwrap();
-    let w_data =
-        Value::Record(
-            vec![
-                ("a_field".to_owned(), Value::Long(13)),
-            ]
-        );
-    let r_data =
-        Value::Union(2, Box::new(Value::Record(
-            vec![
-                ("a_field".to_owned(), Value::Long(13)),
-                ("an_optional_field".to_owned(), Value::Long(42)),
-            ]
-        )));
-    
-    resolve_and_promote_single(
-        &w_schema, &w_schema,
-        w_data.clone(), w_data.clone()
-    ).unwrap();
-    resolve_and_promote_single(
-        &w_schema, &r_schema,
-        w_data.clone(), r_data.clone()
-    ).unwrap();
+        "#,
+    )
+    .unwrap();
+    let w_data = Value::Record(vec![("a_field".to_owned(), Value::Long(13))]);
+    let r_data = Value::Union(
+        2,
+        Box::new(Value::Record(vec![
+            ("a_field".to_owned(), Value::Long(13)),
+            ("an_optional_field".to_owned(), Value::Long(42)),
+        ])),
+    );
+
+    resolve_and_promote_single(&w_schema, &w_schema, w_data.clone(), w_data.clone()).unwrap();
+    resolve_and_promote_single(&w_schema, &r_schema, w_data.clone(), r_data.clone()).unwrap();
 }
 
 #[test]
 fn test_resolve_and_promote_from_union() {
-    let w_schema = 
-        Schema::parse_str(r#"
+    let w_schema = Schema::parse_str(
+        r#"
             [
                 {"type": "long"},
                 {
@@ -629,9 +767,11 @@ fn test_resolve_and_promote_from_union() {
                     ]
                 }
             ]
-        "#).unwrap();
-    let r_schema =
-        Schema::parse_str(r#"
+        "#,
+    )
+    .unwrap();
+    let r_schema = Schema::parse_str(
+        r#"
             {
                 "type": "record",
                 "name": "r2",
@@ -639,44 +779,33 @@ fn test_resolve_and_promote_from_union() {
                     {"name": "a_field", "type": "long"}
                 ]
             }
-        "#).unwrap();
+        "#,
+    )
+    .unwrap();
 
-    let w_data_ok = 
-        Value::Union(2, Box::new(Value::Record(
-            vec![
-                ("a_field".to_owned(), Value::Long(42)),
-            ]
-        )));
+    let w_data_ok = Value::Union(
+        2,
+        Box::new(Value::Record(vec![("a_field".to_owned(), Value::Long(42))])),
+    );
 
-    let w_data_err =
-        Value::Union(1, Box::new(Value::Record(
-            vec![
-                ("an_optional_field".to_owned(), Value::Long(1)),
-            ]
-        )));
+    let w_data_err = Value::Union(
+        1,
+        Box::new(Value::Record(vec![(
+            "an_optional_field".to_owned(),
+            Value::Long(1),
+        )])),
+    );
 
-    let r_data_ok = 
-        Value::Record(
-            vec![
-                ("a_field".to_owned(), Value::Long(42))
-            ]
-        );
-    
-    resolve_and_promote_single(
-        &w_schema, &w_schema,
-        w_data_ok.clone(), w_data_ok.clone()
-    ).unwrap();
+    let r_data_ok = Value::Record(vec![("a_field".to_owned(), Value::Long(42))]);
 
-    resolve_and_promote_single(
-        &w_schema, &r_schema,
-        w_data_ok.clone(), r_data_ok.clone()
-    ).unwrap();
+    resolve_and_promote_single(&w_schema, &w_schema, w_data_ok.clone(), w_data_ok.clone()).unwrap();
 
-    
-    match resolve_and_promote_single(
-        &w_schema, &r_schema,
-        w_data_err.clone(), r_data_ok.clone()
-    ).err().unwrap() {
+    resolve_and_promote_single(&w_schema, &r_schema, w_data_ok.clone(), r_data_ok.clone()).unwrap();
+
+    match resolve_and_promote_single(&w_schema, &r_schema, w_data_err.clone(), r_data_ok.clone())
+        .err()
+        .unwrap()
+    {
         ResolutionError::IncompatibleSchema(_, _) => (),
         _ => assert!(false),
     }
@@ -684,20 +813,26 @@ fn test_resolve_and_promote_from_union() {
 
 #[test]
 fn test_resolve_and_promote_unions() {
-    let w_schema = Schema::parse_str(r#"
+    let w_schema = Schema::parse_str(
+        r#"
         [
             {"type": "null"},
             {"type": "long"},
             {"type": "int"}
         ]
-    "#).unwrap();
-    let r_schema = Schema::parse_str(r#"
+    "#,
+    )
+    .unwrap();
+    let r_schema = Schema::parse_str(
+        r#"
         [
             {"type": "null"},
             {"type": "int"},
             {"type": "boolean"}
         ]
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
 
     let w_null = Value::Union(0, Box::new(Value::Null));
     let r_null = Value::Union(0, Box::new(Value::Null));
@@ -705,34 +840,34 @@ fn test_resolve_and_promote_unions() {
     let w_int = Value::Union(2, Box::new(Value::Int(42)));
     let r_int = Value::Union(1, Box::new(Value::Int(42)));
 
-    resolve_and_promote_single(
-        &w_schema, &r_schema,
-        w_null.clone(), r_null.clone()
-    ).unwrap();
+    resolve_and_promote_single(&w_schema, &r_schema, w_null.clone(), r_null.clone()).unwrap();
 
-    match resolve_and_promote_single(
-        &w_schema, &r_schema,
-        w_long.clone(), w_long.clone()
-    ).err().unwrap() {
+    match resolve_and_promote_single(&w_schema, &r_schema, w_long.clone(), w_long.clone())
+        .err()
+        .unwrap()
+    {
         ResolutionError::IncompatibleSchema(_, _) => (),
         what => assert!(false),
     };
 
-    resolve_and_promote_single(
-        &w_schema, &r_schema,
-        w_int.clone(), r_int.clone()
-    ).unwrap();
+    resolve_and_promote_single(&w_schema, &r_schema, w_int.clone(), r_int.clone()).unwrap();
 }
 
 #[test]
 fn test_resolve_and_promote_enums() {
-    let w_schema = Schema::parse_str(r#"
+    let w_schema = Schema::parse_str(
+        r#"
         {"type": "enum", "name": "e", "symbols": ["a", "b", "c"]}
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
 
-    let r_schema = Schema::parse_str(r#"
+    let r_schema = Schema::parse_str(
+        r#"
         {"type": "enum", "name": "e", "symbols": ["c", "b", "d"]}
-    "#).unwrap();
+    "#,
+    )
+    .unwrap();
 
     let w_a = Value::Enum(0, "a".to_owned());
     let w_b = Value::Enum(1, "b".to_owned());
@@ -740,22 +875,15 @@ fn test_resolve_and_promote_enums() {
     let w_c = Value::Enum(2, "c".to_owned());
     let r_c = Value::Enum(0, "c".to_owned());
 
-    match resolve_and_promote_single(
-        &w_schema, &r_schema,
-        w_a.clone(), w_a.clone()
-    ).err().unwrap() {
+    match resolve_and_promote_single(&w_schema, &r_schema, w_a.clone(), w_a.clone())
+        .err()
+        .unwrap()
+    {
         ResolutionError::IncompatibleData(_) => (),
         what => panic!("{:?}", what),
     };
 
-    resolve_and_promote_single(
-        &w_schema, &r_schema,
-        w_b.clone(), r_b.clone() 
-    ).unwrap();
+    resolve_and_promote_single(&w_schema, &r_schema, w_b.clone(), r_b.clone()).unwrap();
 
-    resolve_and_promote_single(
-        &w_schema, &r_schema,
-        w_c.clone(), r_c.clone()
-    ).unwrap();
+    resolve_and_promote_single(&w_schema, &r_schema, w_c.clone(), r_c.clone()).unwrap();
 }
-

--- a/src/schema_resolution.rs
+++ b/src/schema_resolution.rs
@@ -1,0 +1,761 @@
+
+use std::collections::HashMap;
+
+use crate::Schema;
+use crate::types::Value;
+use crate::schema::Name as RecordName;
+use serde_json::Value as JsonValue;
+use crate::schema::RecordField;
+use crate::types::ToAvro;
+
+#[derive(Fail, Debug, Clone, PartialEq)]
+pub enum ResolutionError {
+    #[fail(display = "ResolutionError::BytesToStringUtf8Error")]
+    BytesToStringUtf8Error,
+    
+    #[fail(display = "ResolutionError::IncompatibleSchema: writer={:?}, reader={:?}", _0, _1)]
+    IncompatibleSchema(Schema, Schema),
+
+    #[fail(display = "ResolutionError::IncompatibleData: data={:?}", _0)]
+    IncompatibleData(Value),
+
+    #[fail(display = "ResolutionError::UnexpectedVariant: variant={}", _0)]
+    UnexpectedVariant(usize),
+
+    #[fail(display = "ResolutionError::RecordFieldMissing: record={:?}, field={}", _0, _1)]
+    RecordFieldMissing(RecordName, usize),
+
+    #[fail(display = "ResolutionError::RecordFieldValueMissing: {}", _0)]
+    RecordFieldValueMissing(String),
+
+    #[fail(display = "ResolutionError::InvalidDefaultValue: {:?}", _0)]
+    InvalidDefaultValue(JsonValue),
+
+    #[fail(display = "ResolutionError::Generic: {}", _0)]
+    Generic(String),
+}
+
+#[derive(Debug, Clone)]
+pub enum RecordFieldResolution {
+    Present {
+        w_pos: usize,
+        r_pos: usize,
+        name: String,
+        resolution: Resolution,
+    },
+
+    Absent {
+        r_pos: usize,
+        name: String,
+        value: Value,
+    }
+}
+// pub struct RecordFieldResolution {
+//     from_pos: usize,
+//     to_pos: usize,
+//     value: Resolution,
+// }
+
+
+#[derive(Debug, Clone)]
+pub enum Resolution {
+    Identity,
+    IntToLong,
+    IntToFloat,
+    IntToDouble,
+    LongToFloat,
+    LongToDouble,
+    FloatToDouble,
+    StringToBytes,
+    BytesToString,
+    Array(Box<Resolution>),
+    Map(Box<Resolution>),
+    Record(Vec<RecordFieldResolution>),
+    UnionVariant(usize, Box<Resolution>),
+    UnionChoice(Vec<Resolution>),
+    EnumChoice(HashMap<i32, (i32, String)>),
+    Failure(ResolutionError),
+}
+
+impl From<std::string::FromUtf8Error> for ResolutionError {
+    fn from(_: std::string::FromUtf8Error) -> ResolutionError {
+        ResolutionError::BytesToStringUtf8Error
+    }
+}
+
+impl Resolution {
+    // pub fn id() -> Resolution {
+    //     Resolution::Identity
+    // }
+
+    pub fn new(writer_schema: &Schema, reader_schema: &Schema) -> Result<Resolution, ResolutionError> {
+        if writer_schema == reader_schema {
+            Ok(Resolution::Identity)
+        } else {
+            match (writer_schema, reader_schema) {
+                // To match, one of the following must hold:
+                // * both schemas have same primitive type ...
+
+                // (Schema::Null, Schema::Null) => Ok(Resolution::Identity),
+                // (Schema::Boolean, Schema::Boolean) => Ok(Resolution::Identity),
+                // (Schema::Int, Schema::Int) => Ok(Resolution::Identity),
+                // (Schema::Long, Schema::Long) => Ok(Resolution::Identity),
+                // (Schema::Float, Schema::Float) => Ok(Resolution::Identity),
+                // (Schema::Double, Schema::Double) => Ok(Resolution::Identity),
+                // (Schema::Bytes, Schema::Bytes) => Ok(Resolution::Identity),
+                // (Schema::String, Schema::String) => Ok(Resolution::Identity),
+
+                // * both schemas are arrays whose item types match
+                (Schema::Array(ref writer_inner), Schema::Array(ref reader_inner)) => 
+                    Self::new(writer_inner, reader_inner)
+                        .map(|inner_resolution| {
+                            match inner_resolution {
+                                Resolution::Identity => Resolution::Identity,
+                                promotion => Resolution::Array(Box::new(promotion))
+                            }
+                        }),
+                // * both schemas are maps whose value types match
+                (Schema::Map(ref writer_inner), Schema::Map(ref reader_inner)) => 
+                    Self::new(writer_inner, reader_inner)
+                        .map(|inner_resolution| {
+                            match inner_resolution {
+                                Resolution::Identity => Resolution::Identity,
+                                promotion => Resolution::Map(Box::new(promotion))
+                            }
+                        }),
+                
+
+                // ... the writer's schema may be promoted to the reader's as follows:
+                // * bytes is promotable to string
+                (Schema::Bytes, Schema::String) => Ok(Resolution::BytesToString),
+                // * string is promotable to bytes
+                (Schema::String, Schema::Bytes) => Ok(Resolution::StringToBytes),
+                // * float is promotable to double
+                (Schema::Float, Schema::Double) => Ok(Resolution::FloatToDouble),
+                // * long is promotable to float or double
+                (Schema::Long, Schema::Float) => Ok(Resolution::LongToFloat),
+                (Schema::Long, Schema::Double) => Ok(Resolution::LongToDouble),
+                // * int is promotable to long, float, or double
+                (Schema::Int, Schema::Long) => Ok(Resolution::IntToLong),
+                (Schema::Int, Schema::Float) => Ok(Resolution::IntToFloat),
+                (Schema::Int, Schema::Double) => Ok(Resolution::IntToDouble),
+
+                /*
+                 * if both are enums:
+                 *  if the writer's symbol is not present in the reader's enum, then an error is signalled.
+                 */
+                (Schema::Enum { name: w_name, symbols: w_symbols, .. }, Schema::Enum { name: r_name, symbols: r_symbols, .. }) if w_name == r_name => {
+                    let r_symbol_map =
+                        r_symbols.iter().enumerate()
+                            .map(|(idx, symbol)| (symbol, idx as i32))
+                            .collect::<HashMap<_, _>>();
+
+                    let translation_map =
+                        w_symbols.iter().enumerate()
+                            .filter_map(|(w_idx, symbol)| 
+                                r_symbol_map
+                                    .get(&symbol)
+                                    .map(|r_idx| (w_idx as i32, (*r_idx, symbol.clone()))) )
+                            .collect::<HashMap<i32, (i32, String)>>();
+
+                    Ok(Resolution::EnumChoice(translation_map))
+                },
+
+                // * if both are unions:
+                //   The first schema in the reader's union that matches the selected writer's union schema is recursively resolved against it. if none match, an error is signalled.
+                (Schema::Union(w_union_schema), r_schema @ Schema::Union(_)) => {
+                    Ok(Resolution::UnionChoice(
+                        w_union_schema.variants().iter()
+                            .map(|w_variant| 
+                                match Self::new(w_variant, r_schema) {
+                                    Ok(resolution) => resolution,
+                                    Err(reason) => Resolution::Failure(reason),
+                                })
+                            .collect::<Vec<_>>()))
+                },
+
+                // * if reader's is a union, but writer's is not
+                //   The first schema in the reader's union that matches the writer's schema is recursively resolved against it. If none match, an error is signalled.
+                (w_non_union, Schema::Union(r_union_schema)) => {
+                    let r_variants = r_union_schema.variants();
+                    r_variants.iter()
+                        .enumerate()
+                        .find_map(|(r_idx, r_variant)| 
+                            Self::new(w_non_union, r_variant)
+                                .ok()
+                                .map(|resolution| Resolution::UnionVariant(r_idx, Box::new(resolution)))
+                        )
+                        .map(|resolution| Ok(resolution))
+                        .unwrap_or_else(|| 
+                            Err(ResolutionError::IncompatibleSchema(
+                                w_non_union.clone(), 
+                                Schema::Union(r_union_schema.clone()))))
+                },
+
+                // * if writer's is a union, but reader's is not
+                //   If the reader's schema matches the selected writer's schema, it is recursively resolved against it. If they do not match, an error is signalled.
+                (Schema::Union(w_union_schema), r_non_union) =>
+                    Ok(
+                        Resolution::UnionChoice(
+                            w_union_schema.variants().iter()
+                                .map(|w_variant| 
+                                    match Self::new(w_variant, r_non_union) {
+                                        Ok(resolution) => resolution,
+                                        Err(reason) => Resolution::Failure(reason),
+                                    })
+                                .collect::<Vec<_>>())),
+
+                (Schema::Record { name: w_name, fields: w_fields, lookup: w_lookup, .. }, Schema::Record { name: r_name, fields: r_fields, .. }) 
+                if r_name == w_name => {
+                    /*
+                    * ... if both are records:
+                    *   - the ordering of fields may be different: fields are matched by name.
+                    *   - schemas for fields with the same name in both records are resolved recursively.
+                    *   - if the writer's record contains a field with a name not present in the reader's record, the writer's value for that field is ignored.
+                    *   - if the reader's record schema has a field that contains a default value, and writer's schema does not have a field with the same name, then the reader should use the default value from its field.
+                    *   - if the reader's record schema has a field with no default value, and writer's schema does not have a field with the same name, an error is signalled.
+                    */
+                    r_fields
+                        .into_iter().enumerate()
+                        .map(|(r_pos, r_field)| {
+                            assert_eq!(r_pos, r_field.position);
+                            
+                            let w_pos_opt: Option<&usize> = w_lookup.get(&r_field.name);
+
+                            let w_pos_and_field_opt: Option<(usize, RecordField)> = w_pos_opt
+                                .map(|w_pos| {
+                                    assert_eq!(*w_pos, w_fields[*w_pos].position);
+
+                                    (*w_pos, w_fields[*w_pos].clone())
+                                });
+
+                            let field_present_result_opt: Option<Result<RecordFieldResolution, ResolutionError>> =
+                                w_pos_and_field_opt
+                                    .map(|(w_pos, w_field)| {
+                                        Self::new(&w_field.schema, &r_field.schema)
+                                            .map(|resolution| {
+                                                RecordFieldResolution::Present {
+                                                    w_pos,
+                                                    r_pos,
+                                                    name: r_field.name.clone(),
+                                                    resolution,
+                                                }
+                                            })
+                                    });
+
+                            let field_result: Result<RecordFieldResolution, ResolutionError> =
+                                field_present_result_opt
+                                    .unwrap_or_else(|| {
+                                        match r_field.default {
+                                            None => 
+                                                Err(ResolutionError::RecordFieldMissing(r_name.clone(), r_pos)),
+                                            Some(ref default_value_json) =>
+                                                Self::value_from_json(&r_field.schema, default_value_json)
+                                                    .map(|default_value|
+                                                        RecordFieldResolution::Absent { 
+                                                            r_pos, 
+                                                            name: r_field.name.clone(),
+                                                            value: default_value
+                                                        })
+                                        }
+                                    });
+
+                            field_result
+                        })
+                        .collect::<Result<_, _>>()
+                        .map(|field_resolutions| Resolution::Record(field_resolutions))
+                },
+
+                (writer_schema, reader_schema) => 
+                    Err(ResolutionError::IncompatibleSchema(writer_schema.clone(), reader_schema.clone())),
+            }
+        }
+    }
+
+    pub fn promote_value(&self, value: Value) -> Result<Value, ResolutionError> {
+        match (self.clone(), value) {
+            (Resolution::Failure(reason), _) => Err(reason),
+            (Resolution::Identity, as_is) => Ok(as_is),
+            
+            (Resolution::IntToLong, Value::Int(v)) => Ok(Value::Long(v.into())),
+            // XXX: I feel really bad for those poor folks who will experience such "promotion" of their values. 
+            (Resolution::IntToFloat, Value::Int(v)) => Ok(Value::Float(v as f32)), // should we check if |v| < 2^24?
+            (Resolution::IntToDouble, Value::Int(v)) => Ok(Value::Double(v.into())),
+            
+            // XXX: See above
+            (Resolution::LongToFloat, Value::Long(v)) => Ok(Value::Float(v as f32)), // should we check if |v| < 2^24?
+            // XXX: See above
+            (Resolution::LongToDouble, Value::Long(v)) => Ok(Value::Double(v as f64)), // should we check if |v| < 2^53?
+
+            (Resolution::FloatToDouble, Value::Float(v)) => Ok(Value::Double(v.into())),
+
+            (Resolution::StringToBytes, Value::String(v)) => Ok(Value::Bytes(v.into_bytes())),
+            (Resolution::BytesToString, Value::Bytes(v)) => Ok(Value::String(String::from_utf8(v)?)),
+
+            (Resolution::Array(inner), Value::Array(vs)) => 
+                vs.into_iter()
+                    .map(|v| inner.promote_value(v))
+                    .collect::<Result<_, _>>()
+                    .map(|vs| Value::Array(vs)),
+
+            (Resolution::Map(inner), Value::Map(vs_map)) => 
+                vs_map
+                    .into_iter()
+                    .map(|(k, v)| inner.promote_value(v).map(|v| (k, v)))
+                    .collect::<Result<Vec<_>, _>>()
+                    .map(|pairs| pairs.into_iter().collect::<HashMap<_, _>>())
+                    .map(|vs_map| Value::Map(vs_map)),
+
+            (Resolution::Record(resolutions), Value::Record(w_fields)) => {
+                let mut w_field_map = w_fields.into_iter().collect::<HashMap<_, _>>();
+
+                resolutions
+                    .into_iter()
+                    .map(|field_resolution| {
+                        match field_resolution {
+                            RecordFieldResolution::Absent { name, value, .. } =>
+                                Ok((name, value)),
+                            RecordFieldResolution::Present { name, resolution, .. } => {
+                                w_field_map.remove(&name)
+                                    .ok_or(ResolutionError::RecordFieldValueMissing(name.clone()))
+                                    .and_then(|w_value| {
+                                        resolution.promote_value(w_value)
+                                    })
+                                    .map(|promoted_value| {
+                                        (name, promoted_value)
+                                    })
+                            },
+                        }
+                    })
+                    .collect::<Result<Vec<(String, Value)>, ResolutionError>>()
+                    .map(|fields| Value::Record(fields))
+            },
+
+            (Resolution::EnumChoice(symbols), Value::Enum(w_idx, w_symbol)) => 
+                symbols.get(&w_idx)
+                    .map(|(r_idx, r_symbol)| Ok(Value::Enum(*r_idx, r_symbol.clone())))
+                    .unwrap_or_else(|| Err(ResolutionError::IncompatibleData(Value::Enum(w_idx, w_symbol)))),
+
+            (Resolution::UnionChoice(variants), Value::Union(idx, value)) =>
+                variants.get(idx)
+                    .map(|resolution| resolution.promote_value(*value))
+                    .unwrap_or_else(|| Err(ResolutionError::UnexpectedVariant(idx))),
+
+            (Resolution::UnionVariant(idx, inner), value) =>
+                inner
+                    .promote_value(value)
+                    .map(|promoted_inner| Value::Union(idx, Box::new(promoted_inner))),
+
+            (_resolution, data) => 
+                Err(ResolutionError::IncompatibleData(data))
+        }
+    }
+
+    fn value_from_json(schema: &Schema, value: &JsonValue) -> Result<Value, ResolutionError> {
+        // Calling .avro() here does not work terribly well for 'int' — it is conservatively cast into Value::Long(_)
+        // Target field schema should be regarded to choose the exact Avro-type.
+        // Illustrated in `schema_resolution::test_resolve_and_promote_record_with_default_int`
+        match (schema, value) {
+            (Schema::Null, JsonValue::Null) => Ok(Value::Null),
+            (Schema::Boolean, JsonValue::Bool(v)) => Ok(Value::Boolean(*v)),
+            (Schema::Int, JsonValue::Number(v)) if v.is_i64() => Ok(Value::Int(v.as_i64().unwrap() as i32)),
+            (Schema::Long, JsonValue::Number(v)) if v.is_i64() => Ok(Value::Long(v.as_i64().unwrap())),
+            (Schema::Float, JsonValue::Number(v)) if v.is_f64() => Ok(Value::Float(v.as_f64().unwrap() as f32)),
+            (Schema::Double, JsonValue::Number(v)) if v.is_f64() => Ok(Value::Double(v.as_f64().unwrap())),
+            (Schema::String, JsonValue::String(v)) => Ok(Value::String(v.clone())),
+            (Schema::Bytes, JsonValue::String(v)) => Ok(Value::Bytes(v.clone().into_bytes())),
+            (Schema::Array(inner), JsonValue::Array(vs)) =>
+                vs.iter()
+                    .map(|v| Self::value_from_json(inner, v))
+                    .collect::<Result<_, _>>()
+                    .map(|vs| Value::Array(vs)),
+            (Schema::Enum { symbols, .. }, JsonValue::String(v)) =>
+                symbols
+                    .iter()
+                    .enumerate()
+                    .find_map(|(idx, symbol)| 
+                        if symbol == v {
+                            Some(Ok(Value::Enum(idx as i32, symbol.clone())))
+                        } else {
+                            None
+                        }
+                    )
+                    .unwrap_or_else(|| 
+                        Err( ResolutionError::InvalidDefaultValue(JsonValue::String(v.to_owned())) )),
+
+            (_, _) => Err(ResolutionError::InvalidDefaultValue(value.clone())),
+        }
+    }
+}
+
+fn resolve_and_promote_single(writer_schema: &Schema, reader_schema: &Schema, original_value: Value, expected_adjusted_value: Value) -> Result<(), ResolutionError> {
+    let resolution = Resolution::new(writer_schema, reader_schema)?;
+    let adjusted_value = resolution.promote_value(original_value)?;
+    if adjusted_value != expected_adjusted_value {
+        Err(ResolutionError::Generic(
+            format!("{:?} != {:?}", adjusted_value, expected_adjusted_value).into()
+        ))
+    } else { 
+        Ok(())
+    }
+}
+
+#[test]
+fn test_resolve_and_promote_primitives() {
+    resolve_and_promote_single(&Schema::Null, &Schema::Null, Value::Null, Value::Null).unwrap();
+    
+    resolve_and_promote_single(&Schema::Boolean, &Schema::Boolean, Value::Boolean(false), Value::Boolean(false)).unwrap();
+    resolve_and_promote_single(&Schema::Boolean, &Schema::Boolean, Value::Boolean(true), Value::Boolean(true)).unwrap();
+    
+    resolve_and_promote_single(&Schema::Int, &Schema::Int, Value::Int(42), Value::Int(42)).unwrap();
+    resolve_and_promote_single(&Schema::Int, &Schema::Long, Value::Int(42), Value::Long(42)).unwrap();
+    resolve_and_promote_single(&Schema::Int, &Schema::Float, Value::Int(42), Value::Float(42.0)).unwrap();
+    resolve_and_promote_single(&Schema::Int, &Schema::Double, Value::Int(42), Value::Double(42.0)).unwrap();
+
+    resolve_and_promote_single(&Schema::Long, &Schema::Long, Value::Long(42), Value::Long(42)).unwrap();
+    resolve_and_promote_single(&Schema::Long, &Schema::Float, Value::Long(42), Value::Float(42.0)).unwrap();
+    resolve_and_promote_single(&Schema::Long, &Schema::Double, Value::Long(42), Value::Double(42.0)).unwrap();
+
+    resolve_and_promote_single(&Schema::Float, &Schema::Float, Value::Float(42.0), Value::Float(42.0)).unwrap();
+    resolve_and_promote_single(&Schema::Float, &Schema::Double, Value::Float(42.0), Value::Double(42.0)).unwrap();
+
+    resolve_and_promote_single(&Schema::Double, &Schema::Double, Value::Double(42.0), Value::Double(42.0)).unwrap();
+
+    resolve_and_promote_single(&Schema::Bytes, &Schema::Bytes, Value::Bytes(vec![1,2,3]), Value::Bytes(vec![1,2,3])).unwrap();
+    resolve_and_promote_single(&Schema::Bytes, &Schema::String, Value::Bytes("abc".to_owned().into_bytes()), Value::String("abc".to_owned())).unwrap();
+
+    resolve_and_promote_single(&Schema::String, &Schema::String, Value::String("abc".to_owned()), Value::String("abc".to_owned())).unwrap();
+    resolve_and_promote_single(&Schema::String, &Schema::Bytes, Value::String("abc".to_owned()), Value::Bytes("abc".to_owned().into_bytes())).unwrap();
+}
+
+#[test]
+fn test_resolve_and_promote_arrays() {
+    resolve_and_promote_single(
+        &Schema::Array(Box::new(Schema::Int)), 
+        &Schema::Array(Box::new(Schema::Int)),
+        Value::Array(vec![Value::Int(1), Value::Int(2)]), 
+        Value::Array(vec![Value::Int(1), Value::Int(2)])).unwrap();
+    resolve_and_promote_single(
+        &Schema::Array(Box::new(Schema::Int)), 
+        &Schema::Array(Box::new(Schema::Long)),
+        Value::Array(vec![Value::Int(1), Value::Int(2)]), 
+        Value::Array(vec![Value::Long(1), Value::Long(2)])).unwrap();
+}
+
+#[test]
+fn test_resolve_and_promote_maps() {
+    resolve_and_promote_single(
+        &Schema::Map(Box::new(Schema::Int)),
+        &Schema::Map(Box::new(Schema::Int)),
+        Value::Map(vec![
+            ("one".to_owned(), Value::Int(1)),
+            ("two".to_owned(), Value::Int(2)),
+            ].into_iter().collect()),
+        Value::Map(vec![
+            ("one".to_owned(), Value::Int(1)),
+            ("two".to_owned(), Value::Int(2)),
+            ].into_iter().collect())
+    ).unwrap();
+    resolve_and_promote_single(
+        &Schema::Map(Box::new(Schema::Int)),
+        &Schema::Map(Box::new(Schema::Long)),
+        Value::Map(vec![
+            ("one".to_owned(), Value::Int(1)),
+            ("two".to_owned(), Value::Int(2)),
+            ].into_iter().collect()),
+        Value::Map(vec![
+            ("one".to_owned(), Value::Long(1)),
+            ("two".to_owned(), Value::Long(2)),
+            ].into_iter().collect())
+    ).unwrap();
+    
+}
+
+#[test]
+fn test_resolve_and_promote_records() {
+    let w_schema = 
+        Schema::parse_str(r#"
+            {
+                "type": "record",
+                "name": "r1",
+                "fields": [
+                    {"name": "a_number_no_default", "type": "int"},
+                    {"name": "a_number_obsolete", "type": "int"}
+                ]
+            }
+        "#).unwrap();
+    let r_schema =
+        Schema::parse_str(r#"
+            {
+                "type": "record",
+                "name": "r1",
+                "fields": [
+                    {"name": "a_number_no_default", "type": "long"},
+                    {"name": "a_number_with_default", "type": "long", "default": 42}
+                ]
+            }
+        "#).unwrap();
+    let w_record = 
+        Value::Record(vec![
+            ("a_number_no_default".to_owned(), Value::Int(13)),
+            ("a_number_obsolete".to_owned(), Value::Int(-1)),
+        ]);
+    let r_record = 
+        Value::Record(vec![
+            ("a_number_no_default".to_owned(), Value::Long(13)),
+            ("a_number_with_default".to_owned(), Value::Long(42)),
+        ]);
+    resolve_and_promote_single(
+        &w_schema, &w_schema,
+        w_record.clone(), w_record.clone()
+    ).unwrap();
+    resolve_and_promote_single(
+        &w_schema, &r_schema,
+        w_record.clone(), r_record.clone()
+    ).unwrap();
+}
+
+#[test]
+fn test_resolve_and_promote_record_with_default_int() {
+    let w_schema = 
+        Schema::parse_str(r#"
+            {
+                "type": "record",
+                "name": "r2",
+                "fields": []
+            }
+        "#).unwrap();
+    let r_schema = 
+        Schema::parse_str(r#"
+            {
+                "type": "record",
+                "name": "r2",
+                "fields": [
+                    {"name": "a_field", "type": "int", "default": 42}
+                ]
+            }
+        "#).unwrap();
+    let w_data = 
+        Value::Record(vec![]);
+    let r_data =
+        Value::Record(vec![
+            ("a_field".to_owned(), Value::Int(42)),
+        ]);
+    resolve_and_promote_single(
+        &w_schema, &w_schema,
+        w_data.clone(), w_data.clone()
+    ).unwrap();
+    resolve_and_promote_single(
+        &w_schema, &r_schema,
+        w_data.clone(), r_data.clone()
+    ).unwrap();
+}
+
+#[test]
+fn test_resolve_and_promote_into_union() {
+    let w_schema = 
+        Schema::parse_str(r#"
+            {
+                "type": "record",
+                "name": "r2",
+                "fields": [
+                    {"name": "a_field", "type": "long"}
+                ]
+            }
+        "#).unwrap();
+    let r_schema =
+        Schema::parse_str(r#"
+            [
+                {"type": "long"},
+                {
+                    "type": "record",
+                    "name": "r1",
+                    "fields": [
+                        {"name": "an_optional_field", "type": "long", "default": 42}
+                    ]
+                },
+                {
+                    "type": "record",
+                    "name": "r2",
+                    "fields": [
+                        {"name": "a_field", "type": "long"},
+                        {"name": "an_optional_field", "type": "long", "default": 42}
+                    ]
+                }
+            ]
+        "#).unwrap();
+    let w_data =
+        Value::Record(
+            vec![
+                ("a_field".to_owned(), Value::Long(13)),
+            ]
+        );
+    let r_data =
+        Value::Union(2, Box::new(Value::Record(
+            vec![
+                ("a_field".to_owned(), Value::Long(13)),
+                ("an_optional_field".to_owned(), Value::Long(42)),
+            ]
+        )));
+    
+    resolve_and_promote_single(
+        &w_schema, &w_schema,
+        w_data.clone(), w_data.clone()
+    ).unwrap();
+    resolve_and_promote_single(
+        &w_schema, &r_schema,
+        w_data.clone(), r_data.clone()
+    ).unwrap();
+}
+
+#[test]
+fn test_resolve_and_promote_from_union() {
+    let w_schema = 
+        Schema::parse_str(r#"
+            [
+                {"type": "long"},
+                {
+                    "type": "record",
+                    "name": "r1",
+                    "fields": [
+                        {"name": "an_optional_field", "type": "long", "default": 42}
+                    ]
+                },
+                {
+                    "type": "record",
+                    "name": "r2",
+                    "fields": [
+                        {"name": "a_field", "type": "long"}
+                    ]
+                }
+            ]
+        "#).unwrap();
+    let r_schema =
+        Schema::parse_str(r#"
+            {
+                "type": "record",
+                "name": "r2",
+                "fields": [
+                    {"name": "a_field", "type": "long"}
+                ]
+            }
+        "#).unwrap();
+
+    let w_data_ok = 
+        Value::Union(2, Box::new(Value::Record(
+            vec![
+                ("a_field".to_owned(), Value::Long(42)),
+            ]
+        )));
+
+    let w_data_err =
+        Value::Union(1, Box::new(Value::Record(
+            vec![
+                ("an_optional_field".to_owned(), Value::Long(1)),
+            ]
+        )));
+
+    let r_data_ok = 
+        Value::Record(
+            vec![
+                ("a_field".to_owned(), Value::Long(42))
+            ]
+        );
+    
+    resolve_and_promote_single(
+        &w_schema, &w_schema,
+        w_data_ok.clone(), w_data_ok.clone()
+    ).unwrap();
+
+    resolve_and_promote_single(
+        &w_schema, &r_schema,
+        w_data_ok.clone(), r_data_ok.clone()
+    ).unwrap();
+
+    
+    match resolve_and_promote_single(
+        &w_schema, &r_schema,
+        w_data_err.clone(), r_data_ok.clone()
+    ).err().unwrap() {
+        ResolutionError::IncompatibleSchema(_, _) => (),
+        _ => assert!(false),
+    }
+}
+
+#[test]
+fn test_resolve_and_promote_unions() {
+    let w_schema = Schema::parse_str(r#"
+        [
+            {"type": "null"},
+            {"type": "long"},
+            {"type": "int"}
+        ]
+    "#).unwrap();
+    let r_schema = Schema::parse_str(r#"
+        [
+            {"type": "null"},
+            {"type": "int"},
+            {"type": "boolean"}
+        ]
+    "#).unwrap();
+
+    let w_null = Value::Union(0, Box::new(Value::Null));
+    let r_null = Value::Union(0, Box::new(Value::Null));
+    let w_long = Value::Union(1, Box::new(Value::Long(42)));
+    let w_int = Value::Union(2, Box::new(Value::Int(42)));
+    let r_int = Value::Union(1, Box::new(Value::Int(42)));
+
+    resolve_and_promote_single(
+        &w_schema, &r_schema,
+        w_null.clone(), r_null.clone()
+    ).unwrap();
+
+    match resolve_and_promote_single(
+        &w_schema, &r_schema,
+        w_long.clone(), w_long.clone()
+    ).err().unwrap() {
+        ResolutionError::IncompatibleSchema(_, _) => (),
+        what => assert!(false),
+    };
+
+    resolve_and_promote_single(
+        &w_schema, &r_schema,
+        w_int.clone(), r_int.clone()
+    ).unwrap();
+}
+
+#[test]
+fn test_resolve_and_promote_enums() {
+    let w_schema = Schema::parse_str(r#"
+        {"type": "enum", "name": "e", "symbols": ["a", "b", "c"]}
+    "#).unwrap();
+
+    let r_schema = Schema::parse_str(r#"
+        {"type": "enum", "name": "e", "symbols": ["c", "b", "d"]}
+    "#).unwrap();
+
+    let w_a = Value::Enum(0, "a".to_owned());
+    let w_b = Value::Enum(1, "b".to_owned());
+    let r_b = Value::Enum(1, "b".to_owned());
+    let w_c = Value::Enum(2, "c".to_owned());
+    let r_c = Value::Enum(0, "c".to_owned());
+
+    match resolve_and_promote_single(
+        &w_schema, &r_schema,
+        w_a.clone(), w_a.clone()
+    ).err().unwrap() {
+        ResolutionError::IncompatibleData(_) => (),
+        what => panic!("{:?}", what),
+    };
+
+    resolve_and_promote_single(
+        &w_schema, &r_schema,
+        w_b.clone(), r_b.clone() 
+    ).unwrap();
+
+    resolve_and_promote_single(
+        &w_schema, &r_schema,
+        w_c.clone(), r_c.clone()
+    ).unwrap();
+}
+

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -24,6 +24,11 @@ pub struct StructSerializer {
     fields: Vec<(String, Value)>,
 }
 
+pub struct VariantStructSerializer {
+    variant_index: usize,
+    fields: Vec<(String, Value)>,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct Error {
     message: String,
@@ -79,16 +84,38 @@ impl StructSerializer {
     }
 }
 
+impl VariantStructSerializer {
+    pub fn new(variant_index: usize, len: usize) -> VariantStructSerializer {
+        VariantStructSerializer {
+            variant_index,
+            fields: Vec::with_capacity(len),
+        }
+    }
+}
+
+pub struct VariantSeqSerializer {
+    variant_index: usize,
+    items: Vec<Value>,
+}
+impl VariantSeqSerializer {
+    pub fn new(variant_index: usize, len: usize) -> VariantSeqSerializer {
+        VariantSeqSerializer {
+            variant_index,
+            items: Vec::with_capacity(len)
+        }
+    }
+}
+
 impl<'b> ser::Serializer for &'b mut Serializer {
     type Ok = Value;
     type Error = Error;
     type SerializeSeq = SeqSerializer;
     type SerializeTuple = SeqSerializer;
     type SerializeTupleStruct = SeqSerializer;
-    type SerializeTupleVariant = SeqSerializer;
+    type SerializeTupleVariant = VariantSeqSerializer;
     type SerializeMap = MapSerializer;
     type SerializeStruct = StructSerializer;
-    type SerializeStructVariant = StructSerializer;
+    type SerializeStructVariant = VariantStructSerializer;
 
     fn serialize_bool(self, v: bool) -> Result<Self::Ok, Self::Error> {
         Ok(Value::Boolean(v))
@@ -170,22 +197,22 @@ impl<'b> ser::Serializer for &'b mut Serializer {
         Ok(Value::Null)
     }
 
-    fn serialize_unit_struct(self, _: &'static str) -> Result<Self::Ok, Self::Error> {
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
         self.serialize_unit()
     }
 
     fn serialize_unit_variant(
         self,
-        _: &'static str,
+        _name: &'static str,
         index: u32,
-        variant: &'static str,
+        _variant: &'static str,
     ) -> Result<Self::Ok, Self::Error> {
-        Ok(Value::Enum(index as i32, variant.to_string()))
+        Ok(Value::Union(index as usize, Box::new(Value::Null)))
     }
 
     fn serialize_newtype_struct<T: ?Sized>(
         self,
-        _: &'static str,
+        _name: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
@@ -196,15 +223,17 @@ impl<'b> ser::Serializer for &'b mut Serializer {
 
     fn serialize_newtype_variant<T: ?Sized>(
         self,
-        _: &'static str,
-        _: u32,
-        _: &'static str,
+        name: &'static str,
+        index: u32,
+        _variant: &'static str,
         value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
         T: Serialize,
     {
-        value.serialize(self)
+
+        let variant_value = self.serialize_newtype_struct(name, value)?;
+        Ok(Value::Union(index as usize, Box::new(variant_value)))
     }
 
     fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
@@ -217,7 +246,7 @@ impl<'b> ser::Serializer for &'b mut Serializer {
 
     fn serialize_tuple_struct(
         self,
-        _: &'static str,
+        _name: &'static str,
         len: usize,
     ) -> Result<Self::SerializeTupleStruct, Self::Error> {
         self.serialize_seq(Some(len))
@@ -225,12 +254,12 @@ impl<'b> ser::Serializer for &'b mut Serializer {
 
     fn serialize_tuple_variant(
         self,
-        _: &'static str,
-        _: u32,
-        _: &'static str,
-        _: usize,
+        _name: &'static str,
+        index: u32,
+        _variant: &'static str,
+        len: usize,
     ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        unimplemented!() // TODO ?
+        Ok(VariantSeqSerializer::new(index as usize, len))
     }
 
     fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
@@ -239,7 +268,7 @@ impl<'b> ser::Serializer for &'b mut Serializer {
 
     fn serialize_struct(
         self,
-        _: &'static str,
+        _name: &'static str,
         len: usize,
     ) -> Result<Self::SerializeStruct, Self::Error> {
         Ok(StructSerializer::new(len))
@@ -247,12 +276,12 @@ impl<'b> ser::Serializer for &'b mut Serializer {
 
     fn serialize_struct_variant(
         self,
-        _: &'static str,
-        _: u32,
-        _: &'static str,
-        _: usize,
+        _name: &'static str,
+        index: u32,
+        _variant: &'static str,
+        len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        unimplemented!() // TODO ?
+        Ok(VariantStructSerializer::new(index as usize, len))
     }
 }
 
@@ -306,19 +335,22 @@ impl ser::SerializeTupleStruct for SeqSerializer {
     }
 }
 
-impl ser::SerializeTupleVariant for SeqSerializer {
+impl ser::SerializeTupleVariant for VariantSeqSerializer {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, _: &T) -> Result<(), Self::Error>
+    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
     where
         T: Serialize,
     {
-        unimplemented!()
+        self.items
+            .push(value.serialize(&mut Serializer::default())?);
+        Ok(())
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        unimplemented!()
+        let variant_value = Value::Array(self.items);
+        Ok(Value::Union(self.variant_index, Box::new(variant_value)))
     }
 }
 
@@ -385,19 +417,24 @@ impl ser::SerializeStruct for StructSerializer {
     }
 }
 
-impl ser::SerializeStructVariant for StructSerializer {
+impl ser::SerializeStructVariant for VariantStructSerializer {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, _: &'static str, _: &T) -> Result<(), Self::Error>
+    fn serialize_field<T: ?Sized>(&mut self, name: &'static str, value: &T) -> Result<(), Self::Error>
     where
         T: Serialize,
     {
-        unimplemented!()
+        self.fields.push((
+            name.to_owned(),
+            value.serialize(&mut Serializer::default())?,
+        ));
+        Ok(())
     }
 
     fn end(self) -> Result<Self::Ok, Self::Error> {
-        unimplemented!()
+        let variant_value = Value::Record(self.fields);
+        Ok(Value::Union(self.variant_index, Box::new(variant_value)))
     }
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -104,7 +104,7 @@ impl VariantSeqSerializer {
     pub fn new(variant_index: usize, len: usize) -> VariantSeqSerializer {
         VariantSeqSerializer {
             variant_index,
-            items: Vec::with_capacity(len)
+            items: Vec::with_capacity(len),
         }
     }
 }
@@ -234,7 +234,6 @@ impl<'b> ser::Serializer for &'b mut Serializer {
     where
         T: Serialize,
     {
-
         let variant_value = self.serialize_newtype_struct(name, value)?;
         Ok(Value::Union(index as usize, Box::new(variant_value)))
     }
@@ -424,7 +423,11 @@ impl ser::SerializeStructVariant for VariantStructSerializer {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, name: &'static str, value: &T) -> Result<(), Self::Error>
+    fn serialize_field<T: ?Sized>(
+        &mut self,
+        name: &'static str,
+        value: &T,
+    ) -> Result<(), Self::Error>
     where
         T: Serialize,
     {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -382,7 +382,7 @@ mod tests {
     #[test]
     fn test_union() {
         let schema = Schema::parse_str(UNION_SCHEMA).unwrap();
-        let union = Value::Union(Box::new(Value::Long(3)));
+        let union = Value::Union(1, Box::new(Value::Long(3)));
 
         let mut expected = Vec::new();
         zig_i64(1, &mut expected);

--- a/tests/serde-structs.rs
+++ b/tests/serde-structs.rs
@@ -1,0 +1,70 @@
+
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate avro_rs;
+
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct NT(i32, i64, bool);
+
+#[test]
+fn serialize_deserialize_newtype() {
+    let values = vec![
+        NT(32, 64, true),
+        NT(23, 46, false),
+    ];
+
+    for input in values {
+        let avro = avro_rs::to_value(input.clone()).expect("Failed to serialize");
+        let output = avro_rs::from_value::<NT>(&avro).expect("Failed to deserialize");
+        assert_eq!(input, output);
+    }
+}
+
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct S1 {
+    a: i32,
+    b: i64,
+    c: bool
+}
+
+#[test]
+fn serialize_deserialize_struct() {
+    let values = vec![
+        S1 { a: 32, b: 64, c: true },
+        S1 { a: 23, b: 46, c: false },
+    ];
+
+    for input in values {
+        let avro = avro_rs::to_value(input.clone()).expect("Failed to serialize");
+        let output = avro_rs::from_value::<S1>(&avro).expect("Failed to deserialize");
+        assert_eq!(input, output);
+    }
+}
+
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+enum E1 {
+    Unit,
+    Newtype(i32, i64, bool),
+    Struct1 { a: i32, b: i64, c: bool },
+    Struct2 { a: i32, b: i64, c: bool },
+}
+
+#[test]
+fn serialize_deserialize_union_types() {
+    let values = vec![
+        E1::Unit,
+        E1::Newtype(32, 64, true),
+        E1::Struct1 { a: 32, b: 64, c: true },
+        E1::Struct2 { a: 23, b: 46, c: false },
+    ];
+
+    for input in values {
+        let avro = avro_rs::to_value(input.clone()).expect("Failed to serialize");
+        let output = avro_rs::from_value::<E1>(&avro).expect("Failed to deserialize");
+        assert_eq!(input, output);
+    }
+}

--- a/tests/serde-structs.rs
+++ b/tests/serde-structs.rs
@@ -1,18 +1,13 @@
-
 #[macro_use]
 extern crate serde;
 extern crate avro_rs;
-
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 struct NT(i32, i64, bool);
 
 #[test]
 fn serialize_deserialize_newtype() {
-    let values = vec![
-        NT(32, 64, true),
-        NT(23, 46, false),
-    ];
+    let values = vec![NT(32, 64, true), NT(23, 46, false)];
 
     for input in values {
         let avro = avro_rs::to_value(input.clone()).expect("Failed to serialize");
@@ -21,19 +16,26 @@ fn serialize_deserialize_newtype() {
     }
 }
 
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 struct S1 {
     a: i32,
     b: i64,
-    c: bool
+    c: bool,
 }
 
 #[test]
 fn serialize_deserialize_struct() {
     let values = vec![
-        S1 { a: 32, b: 64, c: true },
-        S1 { a: 23, b: 46, c: false },
+        S1 {
+            a: 32,
+            b: 64,
+            c: true,
+        },
+        S1 {
+            a: 23,
+            b: 46,
+            c: false,
+        },
     ];
 
     for input in values {
@@ -42,7 +44,6 @@ fn serialize_deserialize_struct() {
         assert_eq!(input, output);
     }
 }
-
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 enum E1 {
@@ -57,8 +58,16 @@ fn serialize_deserialize_union_types() {
     let values = vec![
         E1::Unit,
         E1::Newtype(32, 64, true),
-        E1::Struct1 { a: 32, b: 64, c: true },
-        E1::Struct2 { a: 23, b: 46, c: false },
+        E1::Struct1 {
+            a: 32,
+            b: 64,
+            c: true,
+        },
+        E1::Struct2 {
+            a: 23,
+            b: 46,
+            c: false,
+        },
     ];
 
     for input in values {

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -45,8 +45,8 @@ lazy_static! {
             map.avro()
         }),
         (
-            r#"["string", "null", "long"]"#,
-            Value::Union(Box::new(Value::Null))
+            r#"["null", "string", "long"]"#,
+            Value::Union(0, Box::new(Value::Null))
         ),
         (
             r#"{"type": "record", "name": "Test", "fields": [{"name": "f", "type": "long"}]}"#,


### PR DESCRIPTION
Difference between the `Value::Union` representation this PR and @kphelps 's one: `Value::Union(variant_index: usize, variant_value: Box<Value>)` instead of `Value::Union(union_ref: UnionRef, variant_value: Box<Value>)`.

This option does not allow for creation of union-type instance from the inner variant-value "implicitly" (i.e. without knowing the variant-index able to carry that exact variant-data).
This should help a lot with Serde because this restriction allows "lossless" translations between Structs<->Avro-Values<->Avro-Binary in both directions.

Example of usage: https://gist.github.com/RGafiyatullin/4fec518e3cd8e3c6fe718ca976a4cdc5
Output: https://gist.github.com/RGafiyatullin/8aaf4c427bec5456edde2e0913dde472
