### PR TITLE
Make use of rust 2018 features

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,14 +3,14 @@
     -   id: rust-linting
         name: Rust linting
         description: Run cargo fmt on files included in the commit. rustfmt should be installed before-hand.
-        entry: cargo +nightly fmt --all --
+        entry: cargo fmt --all --
         pass_filenames: true
         types: [file, rust]
         language: system
     -   id: rust-clippy
         name: Rust clippy
         description: Run cargo clippy on files included in the commit. clippy should be installed before-hand.
-        entry: cargo +nightly clippy --all-features --all --
+        entry: cargo clippy --all-features --all --
         pass_filenames: false
         types: [file, rust]
         language: system

--- a/.requirements-precommit.txt
+++ b/.requirements-precommit.txt
@@ -1,1 +1,1 @@
-pre-commit==1.8.2
+pre-commit==1.14.4

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,4 +1,0 @@
-match_block_trailing_comma = true
-trailing_semicolon = false
-use_field_init_shorthand = true
-use_try_shorthand = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,7 @@ rust:
   - nightly
 cache: cargo
 script: ./scripts/travis-test.sh
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,10 @@ snappy = ["byteorder", "crc", "snap"]
 byteorder = { version = "1.0.0", optional = true }
 crc = { version = "1.3.0", optional = true }
 digest = "0.8"
-failure = "0.1.1"
-failure_derive = "0.1.1"
+failure = "0.1.5"
 libflate = "0.1"
-rand = "0.3"
-serde = "1.0"
-serde_derive = "1.0"
+rand = "0.4"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snap = { version = "0.2.3", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -20,20 +20,17 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-avro-rs = "^0.6"
+avro-rs = "0.6"
+failure = "0.1.5"
+serde = { version = "1.0", features = ["derive"] }
 ```
 
 Then try to write and read in Avro format like below:
 
 ```rust
-extern crate avro_rs;
-
-#[macro_use]
-extern crate serde_derive;
-extern crate failure;
-
 use avro_rs::{Codec, Reader, Schema, Writer, from_value, types::Record};
 use failure::Error;
+use serde::{Serialize, Deserialize};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct Test {
@@ -96,11 +93,6 @@ Note: Rabin fingerprinting is NOT SUPPORTED yet.
 An example of fingerprinting for the supported fingerprints:
 
 ```rust
-extern crate avro_rs;
-extern crate failure;
-extern crate md5;
-extern crate sha2;
-
 use avro_rs::Schema;
 use failure::Error;
 use md5::Md5;
@@ -138,14 +130,13 @@ to any allocation it will perform when decoding data.
 
 If you expect some of your data fields to be larger than this limit, be sure
 to make use of the `max_allocation_bytes` function before reading **any** data
-(we leverage Rust's [`std::sync::Once`](https://doc.rust-lang.org/std/sync/struct.Once.html) mechanism to initialize this value, if
+(we leverage Rust's [`std::sync::Once`](https://doc.rust-lang.org/std/sync/struct.Once.html)
+mechanism to initialize this value, if
 any call to decode is made before a call to `max_allocation_bytes`, the limit
 will be 512MB throughout the lifetime of the program).
 
 
 ```rust
-extern crate avro_rs;
-
 use avro_rs::max_allocation_bytes;
 
 

--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -1,12 +1,11 @@
 #![feature(test)]
-
 extern crate test;
 
-extern crate avro_rs;
-use avro_rs::schema::Schema;
-use avro_rs::types::{Record, ToAvro, Value};
-use avro_rs::Reader;
-use avro_rs::Writer;
+use avro_rs::{
+    schema::Schema,
+    types::{Record, ToAvro, Value},
+    Reader, Writer,
+};
 
 static RAW_SMALL_SCHEMA: &'static str = r#"
 {

--- a/benches/serde_json.rs
+++ b/benches/serde_json.rs
@@ -1,7 +1,6 @@
 //! Benchmarks for comparing `avro-rs` to `serde_json`. These benchmarks are meant to be
 //! comparable to those found in `benches/serde.rs`.
 #![feature(test)]
-extern crate serde_json;
 extern crate test;
 
 use serde_json::Value;

--- a/benches/single.rs
+++ b/benches/single.rs
@@ -1,11 +1,11 @@
 #![feature(test)]
-
 extern crate test;
 
-extern crate avro_rs;
-use avro_rs::schema::Schema;
-use avro_rs::to_avro_datum;
-use avro_rs::types::{Record, ToAvro, Value};
+use avro_rs::{
+    schema::Schema,
+    to_avro_datum,
+    types::{Record, ToAvro, Value},
+};
 
 static RAW_SMALL_SCHEMA: &'static str = r#"
 {

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -1,12 +1,10 @@
-extern crate avro_rs;
+use std::time::{Duration, Instant};
 
-use std::time::Duration;
-use std::time::Instant;
-
-use avro_rs::schema::Schema;
-use avro_rs::types::{Record, ToAvro, Value};
-use avro_rs::Reader;
-use avro_rs::Writer;
+use avro_rs::{
+    schema::Schema,
+    types::{Record, ToAvro, Value},
+    Reader, Writer,
+};
 
 fn nanos(duration: Duration) -> u64 {
     duration.as_secs() * 1_000_000_000 + duration.subsec_nanos() as u64

--- a/examples/to_value.rs
+++ b/examples/to_value.rs
@@ -1,11 +1,6 @@
-extern crate avro_rs;
-
-#[macro_use]
-extern crate serde_derive;
-extern crate failure;
-
 use avro_rs::to_value;
 use failure::Error;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct Test {

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,11 +1,16 @@
 //! Logic for serde-compatible deserialization.
-use std::collections::hash_map::{Keys, Values};
-use std::collections::HashMap;
+use std::collections::{
+    hash_map::{Keys, Values},
+    HashMap,
+};
 use std::error::{self, Error as StdError};
 use std::fmt;
 use std::slice::Iter;
 
-use serde::de::{self, Deserialize, DeserializeSeed, Error as SerdeError, Visitor};
+use serde::{
+    de::{self, DeserializeSeed, Error as SerdeError, Visitor},
+    forward_to_deserialize_any, Deserialize,
+};
 
 use crate::types::Value;
 
@@ -138,7 +143,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 String::from_utf8(bytes.to_owned())
                     .map_err(|e| Error::custom(e.description()))
                     .and_then(|s| visitor.visit_string(s))
-            },
+            }
             _ => Err(Error::custom("not a string|bytes|fixed")),
         }
     }
@@ -162,7 +167,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             Value::String(ref s) => visitor.visit_byte_buf(s.clone().into_bytes()),
             Value::Bytes(ref bytes) | Value::Fixed(_, ref bytes) => {
                 visitor.visit_byte_buf(bytes.to_owned())
-            },
+            }
             _ => Err(Error::custom("not a string|bytes|fixed")),
         }
     }
@@ -319,7 +324,8 @@ impl<'de> de::MapAccess<'de> for MapDeserializer<'de> {
             Some(ref key) => seed
                 .deserialize(StringDeserializer {
                     input: (*key).clone(),
-                }).map(Some),
+                })
+                .map(Some),
             None => Ok(None),
         }
     }
@@ -348,8 +354,9 @@ impl<'de> de::MapAccess<'de> for StructDeserializer<'de> {
                 self.value = Some(value);
                 seed.deserialize(StringDeserializer {
                     input: field.clone(),
-                }).map(Some)
-            },
+                })
+                .map(Some)
+            }
             None => Ok(None),
         }
     }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -36,19 +36,19 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
                 1u8 => Ok(Value::Boolean(true)),
                 _ => Err(DecodeError::new("not a bool").into()),
             }
-        },
+        }
         Schema::Int => decode_int(reader),
         Schema::Long => decode_long(reader),
         Schema::Float => {
             let mut buf = [0u8; 4];
             reader.read_exact(&mut buf[..])?;
             Ok(Value::Float(unsafe { transmute::<[u8; 4], f32>(buf) }))
-        },
+        }
         Schema::Double => {
             let mut buf = [0u8; 8];
             reader.read_exact(&mut buf[..])?;
             Ok(Value::Double(unsafe { transmute::<[u8; 8], f64>(buf) }))
-        },
+        }
         Schema::Bytes => {
             let len = decode_len(reader)?;
             let mut buf = Vec::with_capacity(len);
@@ -57,7 +57,7 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
             }
             reader.read_exact(&mut buf)?;
             Ok(Value::Bytes(buf))
-        },
+        }
         Schema::String => {
             let len = decode_len(reader)?;
             let mut buf = Vec::with_capacity(len);
@@ -69,12 +69,12 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
             String::from_utf8(buf)
                 .map(Value::String)
                 .map_err(|_| DecodeError::new("not a valid utf-8 string").into())
-        },
+        }
         Schema::Fixed { size, .. } => {
             let mut buf = vec![0u8; size as usize];
             reader.read_exact(&mut buf)?;
             Ok(Value::Fixed(size, buf))
-        },
+        }
         Schema::Array(ref inner) => {
             let mut items = Vec::new();
 
@@ -83,7 +83,7 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
                 // arrays are 0-terminated, 0i64 is also encoded as 0 in Avro
                 // reading a length of 0 means the end of the array
                 if len == 0 {
-                    break
+                    break;
                 }
 
                 items.reserve(len as usize);
@@ -93,7 +93,7 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
             }
 
             Ok(Value::Array(items))
-        },
+        }
         Schema::Map(ref inner) => {
             let mut items = HashMap::new();
 
@@ -102,7 +102,7 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
                 // maps are 0-terminated, 0i64 is also encoded as 0 in Avro
                 // reading a length of 0 means the end of the map
                 if len == 0 {
-                    break
+                    break;
                 }
 
                 items.reserve(len as usize);
@@ -111,13 +111,13 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
                         let value = decode(inner, reader)?;
                         items.insert(key, value);
                     } else {
-                        return Err(DecodeError::new("map key is not a string").into())
+                        return Err(DecodeError::new("map key is not a string").into());
                     }
                 }
             }
 
             Ok(Value::Map(items))
-        },
+        }
         Schema::Union(ref inner) => {
             let index = zag_i64(reader)?;
             let variants = inner.variants();
@@ -125,7 +125,7 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
                 Some(variant) => decode(variant, reader).map(|x| Value::Union(Box::new(x))),
                 None => Err(DecodeError::new("Union index out of bounds").into()),
             }
-        },
+        }
         Schema::Record { ref fields, .. } => {
             // Benchmarks indicate ~10% improvement using this method.
             let mut items = Vec::new();
@@ -139,7 +139,7 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
             // .map(|field| decode(&field.schema, reader).map(|value| (field.name.clone(), value)))
             // .collect::<Result<Vec<(String, Value)>, _>>()
             // .map(|items| Value::Record(items))
-        },
+        }
         Schema::Enum { ref symbols, .. } => {
             if let Value::Int(index) = decode_int(reader)? {
                 if index >= 0 && (index as usize) <= symbols.len() {
@@ -151,6 +151,6 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
             } else {
                 Err(DecodeError::new("enum symbol not found").into())
             }
-        },
+        }
     }
 }

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -44,12 +44,12 @@ pub fn encode_ref(value: &Value, schema: &Schema, buffer: &mut Vec<u8>) {
         Value::String(s) => match *schema {
             Schema::String => {
                 encode_bytes(s, buffer);
-            },
+            }
             Schema::Enum { ref symbols, .. } => {
                 if let Some(index) = symbols.iter().position(|item| item == s) {
                     encode_int(index as i32, buffer);
                 }
-            },
+            }
             _ => (),
         },
         Value::Fixed(_, bytes) => buffer.extend(bytes),
@@ -64,7 +64,7 @@ pub fn encode_ref(value: &Value, schema: &Schema, buffer: &mut Vec<u8>) {
                 encode_long(idx as i64, buffer);
                 encode_ref(&*item, inner_schema, buffer);
             }
-        },
+        }
         Value::Array(items) => {
             if let Schema::Array(ref inner) = *schema {
                 if items.len() > 0 {
@@ -75,7 +75,7 @@ pub fn encode_ref(value: &Value, schema: &Schema, buffer: &mut Vec<u8>) {
                 }
                 buffer.push(0u8);
             }
-        },
+        }
         Value::Map(items) => {
             if let Schema::Map(ref inner) = *schema {
                 if items.len() > 0 {
@@ -87,7 +87,7 @@ pub fn encode_ref(value: &Value, schema: &Schema, buffer: &mut Vec<u8>) {
                 }
                 buffer.push(0u8);
             }
-        },
+        }
         Value::Record(fields) => {
             if let Schema::Record {
                 fields: ref schema_fields,
@@ -98,7 +98,7 @@ pub fn encode_ref(value: &Value, schema: &Schema, buffer: &mut Vec<u8>) {
                     encode_ref(value, &schema_fields[i].schema, buffer);
                 }
             }
-        },
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,12 +42,6 @@
 //! features = ["snappy"]
 //! ```
 //!
-//! To use the library,  just add at the top of the crate:
-//!
-//! ```
-//! extern crate avro_rs;
-//! ```
-//!
 //! # Defining a schema
 //!
 //! An Avro data cannot exist without an Avro schema. Schemas **must** be used while writing and
@@ -57,7 +51,6 @@
 //! Avro schemas are defined in **JSON** format and can just be parsed out of a raw string:
 //!
 //! ```
-//! # extern crate avro_rs;
 //! use avro_rs::Schema;
 //!
 //! let raw_schema = r#"
@@ -103,7 +96,6 @@
 //! associated type provided by the library to specify the data we want to serialize:
 //!
 //! ```
-//! # extern crate avro_rs;
 //! # use avro_rs::Schema;
 //! use avro_rs::types::Record;
 //! use avro_rs::Writer;
@@ -143,7 +135,6 @@
 //! `Value` interface.
 //!
 //! ```
-//! # extern crate avro_rs;
 //! use avro_rs::types::Value;
 //!
 //! let mut value = Value::String("foo".to_string());
@@ -155,11 +146,8 @@
 //! deriving `Serialize` to model our data:
 //!
 //! ```
-//! # extern crate avro_rs;
-//! #[macro_use]
-//! extern crate serde_derive;
-//!
 //! # use avro_rs::Schema;
+//! # use serde::Serialize;
 //! use avro_rs::Writer;
 //!
 //! #[derive(Debug, Serialize)]
@@ -205,8 +193,6 @@
 //! case we want to directly define an Avro value, any type implementing `Serialize` should work.
 //!
 //! ```
-//! # extern crate avro_rs;
-//!
 //! let mut value = "foo".to_string();
 //! ```
 //!
@@ -224,7 +210,6 @@
 //!
 //! To specify a codec to use to compress data, just specify it while creating a `Writer`:
 //! ```
-//! # extern crate avro_rs;
 //! # use avro_rs::Schema;
 //! use avro_rs::Writer;
 //! use avro_rs::Codec;
@@ -250,7 +235,6 @@
 //! codec:
 //!
 //! ```
-//! # extern crate avro_rs;
 //! use avro_rs::Reader;
 //! # use avro_rs::Schema;
 //! # use avro_rs::types::Record;
@@ -281,7 +265,6 @@
 //! In case, instead, we want to specify a different (but compatible) reader schema from the schema
 //! the data has been written with, we can just do as the following:
 //! ```
-//! # extern crate avro_rs;
 //! use avro_rs::Schema;
 //! use avro_rs::Reader;
 //! # use avro_rs::types::Record;
@@ -342,7 +325,6 @@
 //! We can just read directly instances of `Value` out of the `Reader` iterator:
 //!
 //! ```
-//! # extern crate avro_rs;
 //! # use avro_rs::Schema;
 //! # use avro_rs::types::Record;
 //! # use avro_rs::Writer;
@@ -382,12 +364,9 @@
 //! read the data into:
 //!
 //! ```
-//! # extern crate avro_rs;
-//! #[macro_use]
-//! extern crate serde_derive;
-//!
 //! # use avro_rs::Schema;
 //! # use avro_rs::Writer;
+//! # use serde::{Deserialize, Serialize};
 //! use avro_rs::Reader;
 //! use avro_rs::from_value;
 //!
@@ -433,14 +412,9 @@
 //! quick reference of the library interface:
 //!
 //! ```
-//! extern crate avro_rs;
-//!
-//! #[macro_use]
-//! extern crate serde_derive;
-//! extern crate failure;
-//!
 //! use avro_rs::{Codec, Reader, Schema, Writer, from_value, types::Record};
 //! use failure::Error;
+//! use serde::{Deserialize, Serialize};
 //!
 //! #[derive(Debug, Deserialize, Serialize)]
 //! struct Test {
@@ -490,28 +464,6 @@
 //!     Ok(())
 //! }
 //! ```
-
-extern crate digest;
-extern crate failure;
-#[macro_use]
-extern crate failure_derive;
-extern crate libflate;
-extern crate rand;
-#[macro_use]
-extern crate serde;
-
-extern crate serde_json;
-#[cfg(feature = "snappy")]
-extern crate snap;
-#[cfg(feature = "snappy")]
-extern crate byteorder;
-#[cfg(feature = "snappy")]
-extern crate crc;
-
-// test dependency
-#[cfg(test)]
-#[macro_use]
-extern crate serde_derive;
 
 mod codec;
 mod de;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -51,7 +51,7 @@ impl<R: Read> Block<R> {
         self.reader.read_exact(&mut buf)?;
 
         if buf != [b'O', b'b', b'j', 1u8] {
-            return Err(DecodeError::new("wrong magic in header").into())
+            return Err(DecodeError::new("wrong magic in header").into());
         }
 
         if let Value::Map(meta) = decode(&meta_schema, &mut self.reader)? {
@@ -69,7 +69,7 @@ impl<R: Read> Block<R> {
             if let Some(schema) = schema {
                 self.writer_schema = schema;
             } else {
-                return Err(ParseSchemaError::new("unable to parse schema").into())
+                return Err(ParseSchemaError::new("unable to parse schema").into());
             }
 
             if let Some(codec) = meta
@@ -86,7 +86,7 @@ impl<R: Read> Block<R> {
                 self.codec = codec;
             }
         } else {
-            return Err(DecodeError::new("no metadata in header").into())
+            return Err(DecodeError::new("no metadata in header").into());
         }
 
         let mut buf = [0u8; 16];
@@ -123,7 +123,9 @@ impl<R: Read> Block<R> {
                 self.reader.read_exact(&mut marker)?;
 
                 if marker != self.marker {
-                    return Err(DecodeError::new("block marker does not match header marker").into())
+                    return Err(
+                        DecodeError::new("block marker does not match header marker").into(),
+                    );
                 }
 
                 // NOTE (JAB): This doesn't fit this Reader pattern very well.
@@ -134,12 +136,14 @@ impl<R: Read> Block<R> {
                 // into the buffer. But this is fine, for now.
                 self.codec.decompress(&mut self.buf)?;
 
-                return Ok(())
-            },
-            Err(e) => if let ErrorKind::UnexpectedEof = e.downcast::<::std::io::Error>()?.kind() {
-                // to not return any error in case we only finished to read cleanly from the stream
-                return Ok(())
-            },
+                return Ok(());
+            }
+            Err(e) => {
+                if let ErrorKind::UnexpectedEof = e.downcast::<::std::io::Error>()?.kind() {
+                    // to not return any error in case we only finished to read cleanly from the stream
+                    return Ok(());
+                }
+            }
         };
         Err(DecodeError::new("unable to read block").into())
     }
@@ -156,7 +160,7 @@ impl<R: Read> Block<R> {
         if self.is_empty() {
             self.read_block_next()?;
             if self.is_empty() {
-                return Ok(None)
+                return Ok(None);
             }
         }
 
@@ -252,14 +256,14 @@ impl<'a, R: Read> Iterator for Reader<'a, R> {
     fn next(&mut self) -> Option<Self::Item> {
         // to prevent keep on reading after the first error occurs
         if self.errored {
-            return None
+            return None;
         };
         match self.read_next() {
             Ok(opt) => opt.map(Ok),
             Err(e) => {
                 self.errored = true;
                 Some(Err(e))
-            },
+            }
         }
     }
 }
@@ -287,9 +291,9 @@ pub fn from_avro_datum<R: Read>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Cursor;
     use crate::types::{Record, ToAvro};
     use crate::Reader;
+    use std::io::Cursor;
 
     static SCHEMA: &'static str = r#"
             {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -4,7 +4,10 @@ use std::error;
 use std::fmt;
 use std::iter::once;
 
-use serde::ser::{self, Error as SerdeError, Serialize};
+use serde::{
+    ser::{self, Error as SerdeError},
+    Serialize,
+};
 
 use crate::types::{ToAvro, Value};
 
@@ -413,6 +416,7 @@ pub fn to_value<S: Serialize>(value: S) -> Result<Value, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde::{Deserialize, Serialize};
 
     #[derive(Debug, Deserialize, Serialize)]
     struct Test {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,8 @@
+use std::i64;
 use std::io::Read;
 use std::sync::{Once, ONCE_INIT};
-use std::i64;
 
-use failure::Error;
+use failure::{Error, Fail};
 use serde_json::{Map, Value};
 
 /// Maximum number of bytes that can be allocated when decoding
@@ -94,7 +94,7 @@ fn encode_variable(mut z: u64, buffer: &mut Vec<u8>) {
     loop {
         if z <= 0x7F {
             buffer.push((z & 0x7F) as u8);
-            break
+            break;
         } else {
             buffer.push((0x80 | (z & 0x7F)) as u8);
             z >>= 7;
@@ -110,12 +110,12 @@ fn decode_variable<R: Read>(reader: &mut R) -> Result<u64, Error> {
     loop {
         if j > 9 {
             // if j * 7 > 64
-            return Err(DecodeError::new("Overflow when decoding integer value").into())
+            return Err(DecodeError::new("Overflow when decoding integer value").into());
         }
         reader.read_exact(&mut buf[..])?;
         i |= (u64::from(buf[0] & 0x7F)) << (j * 7);
         if (buf[0] >> 7) == 0 {
-            break
+            break;
         } else {
             j += 1;
         }
@@ -149,7 +149,8 @@ pub fn safe_len(len: usize) -> Result<usize, Error> {
         Err(AllocationError::new(format!(
             "Unable to allocate {} bytes (Maximum allowed: {})",
             len, max_bytes
-        )).into())
+        ))
+        .into())
     }
 }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -2,7 +2,7 @@
 use std::collections::HashMap;
 use std::io::Write;
 
-use failure::Error;
+use failure::{Error, Fail};
 use rand::random;
 use serde::Serialize;
 use serde_json;
@@ -101,7 +101,7 @@ impl<'a, W: Write> Writer<'a, W> {
         self.num_values += 1;
 
         if self.buffer.len() >= SYNC_INTERVAL {
-            return self.flush().map(|b| b + n)
+            return self.flush().map(|b| b + n);
         }
 
         Ok(n)
@@ -129,7 +129,7 @@ impl<'a, W: Write> Writer<'a, W> {
         self.num_values += 1;
 
         if self.buffer.len() >= SYNC_INTERVAL {
-            return self.flush().map(|b| b + n)
+            return self.flush().map(|b| b + n);
         }
 
         Ok(n)
@@ -241,7 +241,7 @@ impl<'a, W: Write> Writer<'a, W> {
     /// Return the number of bytes written.
     pub fn flush(&mut self) -> Result<usize, Error> {
         if self.num_values == 0 {
-            return Ok(0)
+            return Ok(0);
         }
 
         self.codec.compress(&mut self.buffer)?;
@@ -318,7 +318,7 @@ fn write_avro_datum<T: ToAvro>(
 ) -> Result<(), Error> {
     let avro = value.avro();
     if !avro.validate(schema) {
-        return Err(ValidationError::new("value does not match schema").into())
+        return Err(ValidationError::new("value does not match schema").into());
     }
     encode(&avro, schema, buffer);
     Ok(())
@@ -326,7 +326,7 @@ fn write_avro_datum<T: ToAvro>(
 
 fn write_value_ref(schema: &Schema, value: &Value, buffer: &mut Vec<u8>) -> Result<(), Error> {
     if !value.validate(schema) {
-        return Err(ValidationError::new("value does not match schema").into())
+        return Err(ValidationError::new("value does not match schema").into());
     }
     encode_ref(value, schema, buffer);
     Ok(())
@@ -349,6 +349,7 @@ mod tests {
     use super::*;
     use crate::types::Record;
     use crate::util::zig_i64;
+    use serde::{Deserialize, Serialize};
 
     static SCHEMA: &'static str = r#"
             {

--- a/tests/resolve.rs
+++ b/tests/resolve.rs
@@ -1,11 +1,7 @@
-extern crate avro_rs;
-#[macro_use]
-extern crate lazy_static;
-
 use std::io::Cursor;
 
-use avro_rs::types::Value;
-use avro_rs::{from_avro_datum, to_avro_datum, Schema};
+use avro_rs::{from_avro_datum, to_avro_datum, types::Value, Schema};
+use lazy_static::lazy_static;
 
 lazy_static! {
     static ref RAW_RECORD_SCHEMA: &'static str = r#"

--- a/tests/validate.rs
+++ b/tests/validate.rs
@@ -1,12 +1,12 @@
-extern crate avro_rs;
-#[macro_use]
-extern crate lazy_static;
-
 use std::collections::HashMap;
 use std::io::Cursor;
 
-use avro_rs::types::{ToAvro, Value};
-use avro_rs::{from_avro_datum, to_avro_datum, Schema};
+use avro_rs::{
+    from_avro_datum, to_avro_datum,
+    types::{ToAvro, Value},
+    Schema,
+};
+use lazy_static::lazy_static;
 
 // See https://github.com/apache/avro/blob/5af5e399/lang/py/test/test_io.py#L28
 lazy_static! {


### PR DESCRIPTION
- Install rustfmt and clippy on stable
- Drop rustfmt option only available in nightly
- Remove all unecessary extern crate and macro use
- Update serde and failure crate usage of macros
- Optimize some imports
- Bump dependencies
- Also minor adjustments to Makefile