### PR TITLE
Export the encode and decode modules

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -467,13 +467,13 @@
 
 mod codec;
 mod de;
-mod decode;
-mod encode;
 mod reader;
 mod ser;
 mod util;
 mod writer;
 
+pub mod decode;
+pub mod encode;
 pub mod schema;
 pub mod types;
 


### PR DESCRIPTION
Hello. 

I'm trying to perform some low-level operations on Avro files and I found that you have a really nice implementation of the binary codec protocol. What do you think about exporting the modules that implement them?

Thank you for the great work.