### PR TITLE
Fix union resolution

### DIFF
--- a/tests/io.rs
+++ b/tests/io.rs
@@ -51,8 +51,7 @@ lazy_static! {
         (r#"{"type": "enum", "name": "F", "symbols": ["FOO", "BAR"]}"#, r#""FOO""#, Value::Enum(0, "FOO".to_string())),
         (r#"{"type": "array", "items": "int"}"#, "[1, 2, 3]", Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)])),
         (r#"{"type": "map", "values": "int"}"#, r#"{"a": 1, "b": 2}"#, Value::Map([("a".to_string(), Value::Int(1)), ("b".to_string(), Value::Int(2))].iter().cloned().collect())),
-        // TODO: (#96) investigate why this is failing
-        //(r#"["int", "null"]"#, "5", Value::Union(Box::new(Value::Int(5)))),
+        (r#"["int", "null"]"#, "5", Value::Union(Box::new(Value::Int(5)))),
         (r#"{"type": "record", "name": "F", "fields": [{"name": "A", "type": "int"}]}"#, r#"{"A": 5}"#,Value::Record(vec![("A".to_string(), Value::Int(5))])),
     ];
 


### PR DESCRIPTION
See comments in #96 for more info.

I am a bit scared of the performance implications in case of many
union fields with default value null to allow backward compatibility, so
I added an explicit branch in the default resolution to handle null
without a couple more allocations.

The most efficient solution would be to precompute the default value as
part of the schema parsing and store it as the default for the field
instead of its JSON representation, as we are instead doing now.