### PR TITLE
Re-export {de,ser}::Error

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -14,6 +14,7 @@ use serde::{
 
 use crate::types::Value;
 
+/// Represents errors that could be encountered while deserializing data
 #[derive(Clone, Debug, PartialEq)]
 pub struct Error {
     message: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -478,10 +478,10 @@ pub mod schema;
 pub mod types;
 
 pub use crate::codec::Codec;
-pub use crate::de::from_value;
+pub use crate::de::{from_value, Error as DeError};
 pub use crate::reader::{from_avro_datum, Reader};
 pub use crate::schema::{ParseSchemaError, Schema};
-pub use crate::ser::to_value;
+pub use crate::ser::{to_value, Error as SerError};
 pub use crate::types::SchemaResolutionError;
 pub use crate::util::{max_allocation_bytes, DecodeError};
 pub use crate::writer::{to_avro_datum, ValidationError, Writer};

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -27,6 +27,7 @@ pub struct StructSerializer {
     fields: Vec<(String, Value)>,
 }
 
+/// Represents errors that could be encountered while serializing data
 #[derive(Clone, Debug, PartialEq)]
 pub struct Error {
     message: String,


### PR DESCRIPTION
This is useful for people who use the error handling strategy of
defining wrapper Errors around the different kinds of errors that may be
expected. Without making the Error types encountered public it's not
possible to create new error types that wrap them.

I re-exported the errors renamed, as I'm guessing by current code
organization you don't want the de and ser modules public, though that
could just as well be done just making everything non-public as
`pub(crate)`.