### PR TITLE
Port benchmarks to criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,23 @@ edition = "2018"
 [features]
 snappy = ["byteorder", "crc", "snap"]
 
+[lib]
+
+# disable benchmarks to allow passing criterion arguments to `cargo bench`
+bench = false
+
+[[bench]]
+name = "serde"
+harness = false
+
+[[bench]]
+name = "serde_json"
+harness = false
+
+[[bench]]
+name = "single"
+harness = false
+
 [dependencies]
 byteorder = { version = "1.0.0", optional = true }
 crc = { version = "1.3.0", optional = true }
@@ -26,3 +43,4 @@ snap = { version = "0.2.3", optional = true }
 md-5 = "0.8"
 lazy_static = "^1.1"
 sha2 = "0.8"
+criterion = "0.3.1"

--- a/benches/serde_json.rs
+++ b/benches/serde_json.rs
@@ -1,40 +1,26 @@
-//! Benchmarks for comparing `avro-rs` to `serde_json`. These benchmarks are meant to be
-//! comparable to those found in `benches/serde.rs`.
-#![feature(test)]
-extern crate test;
-
 use serde_json::Value;
 use std::collections::HashMap;
+use std::iter::FromIterator;
+
+use criterion::{criterion_group, criterion_main, Criterion};
 
 fn make_big_json_record() -> Value {
-    let mut address = HashMap::new();
-    address.insert("street".to_owned(), "street".to_owned());
-    address.insert("city".to_owned(), "city".to_owned());
-    address.insert("state_prov".to_owned(), "state_prov".to_owned());
-    address.insert("country".to_owned(), "country".to_owned());
-    address.insert("zip".to_owned(), "zip".to_owned());
+    let address = HashMap::<_, _>::from_iter(vec![
+        ("street", "street"),
+        ("city", "city"),
+        ("state_prov", "state_prov"),
+        ("country", "country"),
+        ("zip", "zip"),
+    ]);
     let address_json = serde_json::to_value(address).unwrap();
-    let mut big_record = std::collections::HashMap::new();
-    big_record.insert(
-        "username".to_owned(),
-        serde_json::to_value("username").unwrap(),
-    );
-    big_record.insert("age".to_owned(), serde_json::to_value(10i32).unwrap());
-    big_record.insert(
-        "phone".to_owned(),
-        serde_json::to_value("000000000").unwrap(),
-    );
-    big_record.insert("housenum".to_owned(), serde_json::to_value("0000").unwrap());
-    big_record.insert("address".to_owned(), address_json);
+    let big_record = HashMap::<_, _>::from_iter(vec![
+        ("username", serde_json::to_value("username").unwrap()),
+        ("age", serde_json::to_value(10i32).unwrap()),
+        ("phone", serde_json::to_value("000000000").unwrap()),
+        ("housenum", serde_json::to_value("0000").unwrap()),
+        ("address", address_json),
+    ]);
     serde_json::to_value(big_record).unwrap()
-}
-
-fn make_json_records(record: &Value, count: usize) -> Vec<Value> {
-    let mut records = Vec::with_capacity(count);
-    for _ in 0..count {
-        records.push(record.clone());
-    }
-    records
 }
 
 fn write_json(records: &[Value]) -> Vec<u8> {
@@ -48,16 +34,27 @@ fn read_json(bytes: &[u8]) {
     }
 }
 
-fn bench_read_json(b: &mut test::Bencher, make_record: &Fn() -> (Value), n_records: usize) {
-    let record = make_record();
-    let records = make_json_records(&record, n_records);
+fn bench_read_json(
+    c: &mut Criterion,
+    make_record: impl Fn() -> Value,
+    n_records: usize,
+    name: &'static str,
+) {
+    let records = std::iter::repeat(make_record())
+        .take(n_records)
+        .collect::<Vec<_>>();
     let bytes = write_json(&records);
-    println!("bytes.len() = {}", bytes.len());
-    println!("records.len() = {}", records.len());
-    b.iter(|| read_json(&bytes));
+    c.bench_function(name, |b| b.iter(|| read_json(&bytes)));
 }
 
-#[bench]
-fn bench_big_schema_json_read_10000_record(b: &mut test::Bencher) {
-    bench_read_json(b, &make_big_json_record, 10000);
+fn bench_big_schema_json_read_10000_record(c: &mut Criterion) {
+    bench_read_json(
+        c,
+        &make_big_json_record,
+        10000,
+        "big schema, read 10k JSON records",
+    );
 }
+
+criterion_group!(benches, bench_big_schema_json_read_10000_record);
+criterion_main!(benches);

--- a/benches/single.rs
+++ b/benches/single.rs
@@ -1,5 +1,4 @@
-#![feature(test)]
-extern crate test;
+use criterion::{criterion_group, criterion_main, Criterion};
 
 use avro_rs::{
     schema::Schema,
@@ -156,17 +155,23 @@ fn make_big_record() -> (Schema, Value) {
     (big_schema, big_record)
 }
 
-fn bench_write(b: &mut test::Bencher, make_record: &Fn() -> (Schema, Value)) {
-    let (schema, record) = make_record();
-    b.iter(|| to_avro_datum(&schema, record.clone()));
+fn bench_small_schema_write_record(c: &mut Criterion) {
+    let (schema, record) = make_small_record();
+    c.bench_function("small record", |b| {
+        b.iter(|| to_avro_datum(&schema, record.clone()))
+    });
 }
 
-#[bench]
-fn bench_small_schema_write_record(b: &mut test::Bencher) {
-    bench_write(b, &make_small_record);
+fn bench_big_schema_write_record(c: &mut Criterion) {
+    let (schema, record) = make_big_record();
+    c.bench_function("big record", |b| {
+        b.iter(|| to_avro_datum(&schema, record.clone()))
+    });
 }
 
-#[bench]
-fn bench_big_schema_write_record(b: &mut test::Bencher) {
-    bench_write(b, &make_big_record);
-}
+criterion_group!(
+    benches,
+    bench_small_schema_write_record,
+    bench_big_schema_write_record
+);
+criterion_main!(benches);

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -1,7 +1,10 @@
-#!/bin/bash
-set -ev
+#!/usr/bin/env bash
+
+set -euvxo pipefail
+
 make release
 make test
+
 if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-    make benchmark
+  travis_wait 20 make benchmark
 fi


### PR DESCRIPTION
This PR ports micro benchmarks to criterion.

Criterion works on stable, and is actively maintained and developed.

It also provides much more useful benchmarking data than libtest does.

Finally, it keeps track of the last run and gives useful output indicating possible regressions.