### PR TITLE
Fix f32 and f64 encoding/decoding

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -39,14 +39,14 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
         Schema::Int => decode_int(reader),
         Schema::Long => decode_long(reader),
         Schema::Float => {
-            let mut buf = [0u8; 4];
+            let mut buf = [0u8; std::mem::size_of::<f32>()];
             reader.read_exact(&mut buf[..])?;
-            Ok(Value::Float(f32::from_ne_bytes(buf)))
+            Ok(Value::Float(f32::from_le_bytes(buf)))
         }
         Schema::Double => {
-            let mut buf = [0u8; 8];
+            let mut buf = [0u8; std::mem::size_of::<f64>()];
             reader.read_exact(&mut buf[..])?;
-            Ok(Value::Double(f64::from_ne_bytes(buf)))
+            Ok(Value::Double(f64::from_le_bytes(buf)))
         }
         Schema::Bytes => {
             let len = decode_len(reader)?;

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -36,8 +36,8 @@ pub fn encode_ref(value: &Value, schema: &Schema, buffer: &mut Vec<u8>) {
         Value::Boolean(b) => buffer.push(if *b { 1u8 } else { 0u8 }),
         Value::Int(i) => encode_int(*i, buffer),
         Value::Long(i) => encode_long(*i, buffer),
-        Value::Float(x) => buffer.extend_from_slice(&x.to_ne_bytes()),
-        Value::Double(x) => buffer.extend_from_slice(&x.to_ne_bytes()),
+        Value::Float(x) => buffer.extend_from_slice(&x.to_le_bytes()),
+        Value::Double(x) => buffer.extend_from_slice(&x.to_le_bytes()),
         Value::Bytes(bytes) => encode_bytes(bytes, buffer),
         Value::String(s) => match *schema {
             Schema::String => {


### PR DESCRIPTION
`avro-rs` currently doesn't conform to the binary encoding spec for `f32` and `f64` values which states:

```
* a float is written as 4 bytes. The float is converted into a 32-bit integer using a method equivalent to Java's floatToIntBits and then encoded in little-endian format.
* a double is written as 8 bytes. The double is converted into a 64-bit integer using a method equivalent to Java's doubleToLongBits and then encoded in little-endian format.
```

This PR fixes that.

ref: https://avro.apache.org/docs/1.8.1/spec.html#binary_encode_primitive