### PR TITLE
fix-for-reusing-enum-references

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rand = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 snap = { version = "0.2.3", optional = true }
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 md-5 = "0.8"

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -287,6 +287,36 @@ lazy_static! {
             }"#,
             false
         ),
+        (
+            r#"{
+                  "type": "record",
+                  "name": "mymsg",
+                  "namespace": "myns",
+                  "fields": [
+                    {
+                      "name": "myid",
+                      "type": "int"
+                    },
+                    {
+                      "name": "c1",
+                      "type": {
+                        "type": "enum",
+                        "name": "myflag",
+                        "symbols": [
+                          "A",
+                          "B",
+                          "C"
+                        ]
+                      }
+                    },
+                    {
+                      "name": "c2",
+                      "type": "myflag"
+                    }
+                  ]
+            }"#,
+            true
+        ),
     ];
     static ref DOC_EXAMPLES: Vec<(&'static str, bool)> = vec![
         (


### PR DESCRIPTION
Hi,

I fixed the issue raised by me earlier, the fix is to be able to process following schema type

```
{
  "type": "record",
  "name": "mymsg",
  "namespace": "myns",
  "fields": [
    {
      "name": "myid",
      "type": "int"
    },
    {
      "name": "c1",
      "type": {
        "type": "enum",
        "name": "myflag",
        "symbols": [
          "A",
          "B",
          "C"
        ]
      }
    },
    {
      "name": "c2",
      "type": "myflag"
    }
  ]
}
```