### PR TITLE
Add a test for nullable logical types

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1187,4 +1187,16 @@ mod tests {
             Schema::parse_str(r#"{"type": "long", "logicalType": "timestamp-micros"}"#).unwrap();
         assert_eq!(schema, Schema::TimestampMicros);
     }
+
+    #[test]
+    fn test_nullable_logical_type() {
+        let schema = Schema::parse_str(
+            r#"{"type": ["null", {"type": "long", "logicalType": "timestamp-micros"}]}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            schema,
+            Schema::Union(UnionSchema::new(vec![Schema::Null, Schema::TimestampMicros]).unwrap())
+        );
+    }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -568,8 +568,7 @@ mod tests {
         zig_i64(27, &mut data);
         zig_i64(3, &mut data);
         data.extend(b"foo");
-        let data_copy = data.clone();
-        data.extend(data_copy);
+        data.extend(data.clone());
 
         // starts with magic
         assert_eq!(result.as_slice()[..header.len()].to_vec(), header);
@@ -604,8 +603,7 @@ mod tests {
         zig_i64(27, &mut data);
         zig_i64(3, &mut data);
         data.extend(b"foo");
-        let data_copy = data.clone();
-        data.extend(data_copy);
+        data.extend(data.clone());
 
         // starts with magic
         assert_eq!(result.as_slice()[..header.len()].to_vec(), header);
@@ -680,8 +678,7 @@ mod tests {
         zig_i64(27, &mut data);
         zig_i64(3, &mut data);
         data.extend(b"foo");
-        let data_copy = data.clone();
-        data.extend(data_copy);
+        data.extend(data.clone());
 
         // starts with magic
         assert_eq!(result.as_slice()[..header.len()].to_vec(), header);

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -14,7 +14,7 @@ use crate::types::{ToAvro, Value};
 use crate::Codec;
 
 const DEFAULT_BLOCK_SIZE: usize = 16000;
-const AVRO_OBJECT_HEADER: [u8; 4] = [b'O', b'b', b'j', 1_u8];
+const AVRO_OBJECT_HEADER: &[u8] = b"Obj\x01";
 
 /// Describes errors happened while validating Avro data.
 #[derive(Fail, Debug)]
@@ -291,7 +291,7 @@ impl<'a, W: Write> Writer<'a, W> {
         metadata.insert("avro.codec", self.codec.avro());
 
         let mut header = Vec::new();
-        header.extend_from_slice(&AVRO_OBJECT_HEADER);
+        header.extend_from_slice(AVRO_OBJECT_HEADER);
         encode(
             &metadata.avro(),
             &Schema::Map(Box::new(Schema::Bytes)),
@@ -350,6 +350,8 @@ mod tests {
     use crate::types::Record;
     use crate::util::zig_i64;
     use serde::{Deserialize, Serialize};
+
+    const AVRO_OBJECT_HEADER_LEN: usize = AVRO_OBJECT_HEADER.len();
 
     const SCHEMA: &str = r#"
     {
@@ -569,15 +571,12 @@ mod tests {
         data.extend(data.clone());
 
         // starts with magic
-        assert_eq!(
-            &result.as_slice()[..AVRO_OBJECT_HEADER.len()],
-            &AVRO_OBJECT_HEADER[..]
-        );
+        assert_eq!(&result[..AVRO_OBJECT_HEADER_LEN], AVRO_OBJECT_HEADER);
         // ends with data and sync marker
         let last_data_byte = result.len() - 16;
         assert_eq!(
-            result.as_slice()[last_data_byte - data.len()..last_data_byte].to_vec(),
-            data
+            &result[last_data_byte - data.len()..last_data_byte],
+            data.as_slice()
         );
     }
 
@@ -605,15 +604,12 @@ mod tests {
         data.extend(data.clone());
 
         // starts with magic
-        assert_eq!(
-            &result.as_slice()[..AVRO_OBJECT_HEADER.len()],
-            &AVRO_OBJECT_HEADER[..]
-        );
+        assert_eq!(&result[..AVRO_OBJECT_HEADER_LEN], AVRO_OBJECT_HEADER);
         // ends with data and sync marker
         let last_data_byte = result.len() - 16;
         assert_eq!(
-            result.as_slice()[last_data_byte - data.len()..last_data_byte].to_vec(),
-            data
+            &result[last_data_byte - data.len()..last_data_byte],
+            data.as_slice()
         );
     }
 
@@ -645,15 +641,12 @@ mod tests {
         data.extend(b"foo");
 
         // starts with magic
-        assert_eq!(
-            &result.as_slice()[..AVRO_OBJECT_HEADER.len()],
-            &AVRO_OBJECT_HEADER[..]
-        );
+        assert_eq!(&result[..AVRO_OBJECT_HEADER_LEN], AVRO_OBJECT_HEADER);
         // ends with data and sync marker
         let last_data_byte = result.len() - 16;
         assert_eq!(
-            result.as_slice()[last_data_byte - data.len()..last_data_byte].to_vec(),
-            data
+            &result[last_data_byte - data.len()..last_data_byte],
+            data.as_slice()
         );
     }
 
@@ -682,15 +675,12 @@ mod tests {
         data.extend(data.clone());
 
         // starts with magic
-        assert_eq!(
-            &result.as_slice()[..AVRO_OBJECT_HEADER.len()],
-            &AVRO_OBJECT_HEADER[..]
-        );
+        assert_eq!(&result[..AVRO_OBJECT_HEADER_LEN], AVRO_OBJECT_HEADER);
         // ends with data and sync marker
         let last_data_byte = result.len() - 16;
         assert_eq!(
-            result.as_slice()[last_data_byte - data.len()..last_data_byte].to_vec(),
-            data
+            &result[last_data_byte - data.len()..last_data_byte],
+            data.as_slice()
         );
     }
 
@@ -727,15 +717,12 @@ mod tests {
         Codec::Deflate.compress(&mut data).unwrap();
 
         // starts with magic
-        assert_eq!(
-            &result.as_slice()[..AVRO_OBJECT_HEADER.len()],
-            &AVRO_OBJECT_HEADER[..]
-        );
+        assert_eq!(&result[..AVRO_OBJECT_HEADER_LEN], AVRO_OBJECT_HEADER);
         // ends with data and sync marker
         let last_data_byte = result.len() - 16;
         assert_eq!(
-            result.as_slice()[last_data_byte - data.len()..last_data_byte].to_vec(),
-            data
+            &result[last_data_byte - data.len()..last_data_byte],
+            data.as_slice()
         );
     }
 
@@ -798,7 +785,7 @@ mod tests {
         assert_eq!(n1 + n2 + n3, result.len());
 
         let mut data = Vec::new();
-        // byte indicating _not_ null
+        // byte indicating not null
         zig_i64(1, &mut data);
         zig_i64(1234, &mut data);
 
@@ -807,15 +794,12 @@ mod tests {
         codec.compress(&mut data).unwrap();
 
         // starts with magic
-        assert_eq!(
-            &result.as_slice()[..AVRO_OBJECT_HEADER.len()],
-            &AVRO_OBJECT_HEADER[..]
-        );
+        assert_eq!(&result[..AVRO_OBJECT_HEADER_LEN], AVRO_OBJECT_HEADER);
         // ends with data and sync marker
         let last_data_byte = result.len() - 16;
         assert_eq!(
-            result.as_slice()[last_data_byte - data.len()..last_data_byte].to_vec(),
-            data
+            &result[last_data_byte - data.len()..last_data_byte],
+            data.as_slice()
         );
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -386,13 +386,24 @@ mod tests {
     }
 
     #[test]
-    fn test_union() {
+    fn test_union_not_null() {
         let schema = Schema::parse_str(UNION_SCHEMA).unwrap();
         let union = Value::Union(Box::new(Value::Long(3)));
 
         let mut expected = Vec::new();
         zig_i64(1, &mut expected);
         zig_i64(3, &mut expected);
+
+        assert_eq!(to_avro_datum(&schema, union).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_union_null() {
+        let schema = Schema::parse_str(UNION_SCHEMA).unwrap();
+        let union = Value::Union(Box::new(Value::Null));
+
+        let mut expected = Vec::new();
+        zig_i64(0, &mut expected);
 
         assert_eq!(to_avro_datum(&schema, union).unwrap(), expected);
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -562,37 +562,21 @@ mod tests {
 
         assert_eq!(n1 + n2 + n3, result.len());
 
-        let mut header = Vec::new();
-        header.extend(vec![b'O', b'b', b'j', b'\x01']);
+        let header = b"Obj\x01".to_vec();
 
         let mut data = Vec::new();
         zig_i64(27, &mut data);
         zig_i64(3, &mut data);
-        data.extend(vec![b'f', b'o', b'o'].into_iter());
+        data.extend(b"foo");
         let data_copy = data.clone();
         data.extend(data_copy);
 
         // starts with magic
-        assert_eq!(
-            result
-                .iter()
-                .cloned()
-                .take(header.len())
-                .collect::<Vec<u8>>(),
-            header
-        );
+        assert_eq!(result.as_slice()[..header.len()].to_vec(), header);
         // ends with data and sync marker
+        let last_data_byte = result.len() - 16;
         assert_eq!(
-            result
-                .iter()
-                .cloned()
-                .rev()
-                .skip(16)
-                .take(data.len())
-                .collect::<Vec<u8>>()
-                .into_iter()
-                .rev()
-                .collect::<Vec<u8>>(),
+            result.as_slice()[last_data_byte - data.len()..last_data_byte].to_vec(),
             data
         );
     }
@@ -614,37 +598,21 @@ mod tests {
 
         assert_eq!(n1 + n2, result.len());
 
-        let mut header = Vec::new();
-        header.extend(vec![b'O', b'b', b'j', b'\x01']);
+        let header = b"Obj\x01".to_vec();
 
         let mut data = Vec::new();
         zig_i64(27, &mut data);
         zig_i64(3, &mut data);
-        data.extend(vec![b'f', b'o', b'o'].into_iter());
+        data.extend(b"foo");
         let data_copy = data.clone();
         data.extend(data_copy);
 
         // starts with magic
-        assert_eq!(
-            result
-                .iter()
-                .cloned()
-                .take(header.len())
-                .collect::<Vec<u8>>(),
-            header
-        );
+        assert_eq!(result.as_slice()[..header.len()].to_vec(), header);
         // ends with data and sync marker
+        let last_data_byte = result.len() - 16;
         assert_eq!(
-            result
-                .iter()
-                .cloned()
-                .rev()
-                .skip(16)
-                .take(data.len())
-                .collect::<Vec<u8>>()
-                .into_iter()
-                .rev()
-                .collect::<Vec<u8>>(),
+            result.as_slice()[last_data_byte - data.len()..last_data_byte].to_vec(),
             data
         );
     }
@@ -671,35 +639,19 @@ mod tests {
 
         assert_eq!(n1 + n2, result.len());
 
-        let mut header = Vec::new();
-        header.extend(vec![b'O', b'b', b'j', b'\x01']);
+        let header = b"Obj\x01".to_vec();
 
         let mut data = Vec::new();
         zig_i64(27, &mut data);
         zig_i64(3, &mut data);
-        data.extend(vec![b'f', b'o', b'o'].into_iter());
+        data.extend(b"foo");
 
         // starts with magic
-        assert_eq!(
-            result
-                .iter()
-                .cloned()
-                .take(header.len())
-                .collect::<Vec<u8>>(),
-            header
-        );
+        assert_eq!(result.as_slice()[..header.len()].to_vec(), header);
         // ends with data and sync marker
+        let last_data_byte = result.len() - 16;
         assert_eq!(
-            result
-                .iter()
-                .cloned()
-                .rev()
-                .skip(16)
-                .take(data.len())
-                .collect::<Vec<u8>>()
-                .into_iter()
-                .rev()
-                .collect::<Vec<u8>>(),
+            result.as_slice()[last_data_byte - data.len()..last_data_byte].to_vec(),
             data
         );
     }
@@ -722,37 +674,21 @@ mod tests {
 
         assert_eq!(n1 + n2, result.len());
 
-        let mut header = Vec::new();
-        header.extend(vec![b'O', b'b', b'j', b'\x01']);
+        let header = b"Obj\x01".to_vec();
 
         let mut data = Vec::new();
         zig_i64(27, &mut data);
         zig_i64(3, &mut data);
-        data.extend(vec![b'f', b'o', b'o'].into_iter());
+        data.extend(b"foo");
         let data_copy = data.clone();
         data.extend(data_copy);
 
         // starts with magic
-        assert_eq!(
-            result
-                .iter()
-                .cloned()
-                .take(header.len())
-                .collect::<Vec<u8>>(),
-            header
-        );
+        assert_eq!(result.as_slice()[..header.len()].to_vec(), header);
         // ends with data and sync marker
+        let last_data_byte = result.len() - 16;
         assert_eq!(
-            result
-                .iter()
-                .cloned()
-                .rev()
-                .skip(16)
-                .take(data.len())
-                .collect::<Vec<u8>>()
-                .into_iter()
-                .rev()
-                .collect::<Vec<u8>>(),
+            result.as_slice()[last_data_byte - data.len()..last_data_byte].to_vec(),
             data
         );
     }
@@ -782,38 +718,20 @@ mod tests {
 
         assert_eq!(n1 + n2 + n3, result.len());
 
-        let mut header = Vec::new();
-        header.extend(vec![b'O', b'b', b'j', b'\x01']);
-
+        let header = b"Obj\x01".to_vec();
         let mut data = Vec::new();
         zig_i64(27, &mut data);
         zig_i64(3, &mut data);
-        data.extend(vec![b'f', b'o', b'o'].into_iter());
-        let data_copy = data.clone();
-        data.extend(data_copy);
+        data.extend(b"foo");
+        data.extend(data.clone());
         Codec::Deflate.compress(&mut data).unwrap();
 
         // starts with magic
-        assert_eq!(
-            result
-                .iter()
-                .cloned()
-                .take(header.len())
-                .collect::<Vec<u8>>(),
-            header
-        );
+        assert_eq!(result.as_slice()[..header.len()].to_vec(), header);
         // ends with data and sync marker
+        let last_data_byte = result.len() - 16;
         assert_eq!(
-            result
-                .iter()
-                .cloned()
-                .rev()
-                .skip(16)
-                .take(data.len())
-                .collect::<Vec<u8>>()
-                .into_iter()
-                .rev()
-                .collect::<Vec<u8>>(),
+            result.as_slice()[last_data_byte - data.len()..last_data_byte].to_vec(),
             data
         );
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -14,7 +14,7 @@ use crate::types::{ToAvro, Value};
 use crate::Codec;
 
 const DEFAULT_BLOCK_SIZE: usize = 16000;
-const AVRO_OBJECT_HEADER: &[u8] = &[b'O', b'b', b'j', 1u8];
+const AVRO_OBJECT_HEADER: [u8; 4] = [b'O', b'b', b'j', 1_u8];
 
 /// Describes errors happened while validating Avro data.
 #[derive(Fail, Debug)]
@@ -291,7 +291,7 @@ impl<'a, W: Write> Writer<'a, W> {
         metadata.insert("avro.codec", self.codec.avro());
 
         let mut header = Vec::new();
-        header.extend_from_slice(AVRO_OBJECT_HEADER);
+        header.extend_from_slice(&AVRO_OBJECT_HEADER);
         encode(
             &metadata.avro(),
             &Schema::Map(Box::new(Schema::Bytes)),
@@ -562,8 +562,6 @@ mod tests {
 
         assert_eq!(n1 + n2 + n3, result.len());
 
-        let header = b"Obj\x01".to_vec();
-
         let mut data = Vec::new();
         zig_i64(27, &mut data);
         zig_i64(3, &mut data);
@@ -571,7 +569,10 @@ mod tests {
         data.extend(data.clone());
 
         // starts with magic
-        assert_eq!(result.as_slice()[..header.len()].to_vec(), header);
+        assert_eq!(
+            &result.as_slice()[..AVRO_OBJECT_HEADER.len()],
+            &AVRO_OBJECT_HEADER[..]
+        );
         // ends with data and sync marker
         let last_data_byte = result.len() - 16;
         assert_eq!(
@@ -597,8 +598,6 @@ mod tests {
 
         assert_eq!(n1 + n2, result.len());
 
-        let header = b"Obj\x01".to_vec();
-
         let mut data = Vec::new();
         zig_i64(27, &mut data);
         zig_i64(3, &mut data);
@@ -606,7 +605,10 @@ mod tests {
         data.extend(data.clone());
 
         // starts with magic
-        assert_eq!(result.as_slice()[..header.len()].to_vec(), header);
+        assert_eq!(
+            &result.as_slice()[..AVRO_OBJECT_HEADER.len()],
+            &AVRO_OBJECT_HEADER[..]
+        );
         // ends with data and sync marker
         let last_data_byte = result.len() - 16;
         assert_eq!(
@@ -637,15 +639,16 @@ mod tests {
 
         assert_eq!(n1 + n2, result.len());
 
-        let header = b"Obj\x01".to_vec();
-
         let mut data = Vec::new();
         zig_i64(27, &mut data);
         zig_i64(3, &mut data);
         data.extend(b"foo");
 
         // starts with magic
-        assert_eq!(result.as_slice()[..header.len()].to_vec(), header);
+        assert_eq!(
+            &result.as_slice()[..AVRO_OBJECT_HEADER.len()],
+            &AVRO_OBJECT_HEADER[..]
+        );
         // ends with data and sync marker
         let last_data_byte = result.len() - 16;
         assert_eq!(
@@ -672,8 +675,6 @@ mod tests {
 
         assert_eq!(n1 + n2, result.len());
 
-        let header = b"Obj\x01".to_vec();
-
         let mut data = Vec::new();
         zig_i64(27, &mut data);
         zig_i64(3, &mut data);
@@ -681,7 +682,10 @@ mod tests {
         data.extend(data.clone());
 
         // starts with magic
-        assert_eq!(result.as_slice()[..header.len()].to_vec(), header);
+        assert_eq!(
+            &result.as_slice()[..AVRO_OBJECT_HEADER.len()],
+            &AVRO_OBJECT_HEADER[..]
+        );
         // ends with data and sync marker
         let last_data_byte = result.len() - 16;
         assert_eq!(
@@ -715,7 +719,6 @@ mod tests {
 
         assert_eq!(n1 + n2 + n3, result.len());
 
-        let header = b"Obj\x01".to_vec();
         let mut data = Vec::new();
         zig_i64(27, &mut data);
         zig_i64(3, &mut data);
@@ -724,7 +727,10 @@ mod tests {
         Codec::Deflate.compress(&mut data).unwrap();
 
         // starts with magic
-        assert_eq!(result.as_slice()[..header.len()].to_vec(), header);
+        assert_eq!(
+            &result.as_slice()[..AVRO_OBJECT_HEADER.len()],
+            &AVRO_OBJECT_HEADER[..]
+        );
         // ends with data and sync marker
         let last_data_byte = result.len() - 16;
         assert_eq!(
@@ -791,8 +797,6 @@ mod tests {
 
         assert_eq!(n1 + n2 + n3, result.len());
 
-        let header = b"Obj\x01".to_vec();
-
         let mut data = Vec::new();
         // byte indicating _not_ null
         zig_i64(1, &mut data);
@@ -803,7 +807,10 @@ mod tests {
         codec.compress(&mut data).unwrap();
 
         // starts with magic
-        assert_eq!(result.as_slice()[..header.len()].to_vec(), header);
+        assert_eq!(
+            &result.as_slice()[..AVRO_OBJECT_HEADER.len()],
+            &AVRO_OBJECT_HEADER[..]
+        );
         // ends with data and sync marker
         let last_data_byte = result.len() - 16;
         assert_eq!(


### PR DESCRIPTION
This PR adds a test for writing a nullable logical type.

Nullable logical types are specified using union of `null`, and the logical type:

```
{"type": ["null", {"type": "long", "logicalType": "timestamp-micros"}]}
```

Closes #122.