### PR TITLE
Share field names in Schema::Record

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ libflate = "0.1"
 num-bigint = "0.2.6"
 rand = "0.4"
 serde_json = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 snap = { version = "0.2.3", optional = true }
 strum = "0.18.0"
 strum_macros = "0.18.0"

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -67,12 +67,12 @@ pub fn encode_ref(value: &Value, schema: &Schema, buffer: &mut Vec<u8>) {
         }
         Value::Uuid(uuid) => encode_bytes(&uuid.to_string(), buffer),
         Value::Bytes(bytes) => encode_bytes(bytes, buffer),
-        Value::String(s) => match *schema {
+        Value::String(ref s) => match *schema {
             Schema::String => {
                 encode_bytes(s, buffer);
             }
             Schema::Enum { ref symbols, .. } => {
-                if let Some(index) = symbols.iter().position(|item| item == s) {
+                if let Some(index) = symbols.iter().position(|item| item.as_ref() == s) {
                     encode_int(index as i32, buffer);
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -613,6 +613,7 @@ mod tests {
     use crate::reader::Reader;
     use crate::schema::Schema;
     use crate::types::{Record, Value};
+    use std::sync::Arc;
 
     //TODO: move where it fits better
     #[test]
@@ -659,9 +660,12 @@ mod tests {
         assert_eq!(
             reader.next().unwrap().unwrap(),
             Value::Record(vec![
-                ("a".to_string(), Value::Long(27)),
-                ("b".to_string(), Value::String("foo".to_string())),
-                ("c".to_string(), Value::Enum(1, "spades".to_string())),
+                (Arc::new("a".to_string()), Value::Long(27)),
+                (Arc::new("b".to_string()), Value::String("foo".to_string())),
+                (
+                    Arc::new("c".to_string()),
+                    Value::Enum(1, Arc::new("spades".to_string()))
+                ),
             ])
         );
         assert!(reader.next().is_none());
@@ -702,9 +706,12 @@ mod tests {
         assert_eq!(
             reader.next().unwrap().unwrap(),
             Value::Record(vec![
-                ("a".to_string(), Value::Long(27)),
-                ("b".to_string(), Value::String("foo".to_string())),
-                ("c".to_string(), Value::Enum(2, "clubs".to_string())),
+                (Arc::new("a".to_string()), Value::Long(27)),
+                (Arc::new("b".to_string()), Value::String("foo".to_string())),
+                (
+                    Arc::new("c".to_string()),
+                    Value::Enum(2, Arc::new("clubs".to_string()))
+                ),
             ])
         );
         assert!(reader.next().is_none());
@@ -801,9 +808,12 @@ mod tests {
         assert_eq!(
             reader.next().unwrap().unwrap(),
             Value::Record(vec![
-                ("a".to_string(), Value::Long(27)),
-                ("b".to_string(), Value::String("foo".to_string())),
-                ("c".to_string(), Value::Enum(2, "clubs".to_string())),
+                (Arc::new("a".to_string()), Value::Long(27)),
+                (Arc::new("b".to_string()), Value::String("foo".to_string())),
+                (
+                    Arc::new("c".to_string()),
+                    Value::Enum(2, Arc::new("clubs".to_string()))
+                ),
             ])
         );
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -183,7 +183,7 @@ impl<'a> From<&'a types::Value> for SchemaKind {
 /// [Avro specification](https://avro.apache.org/docs/current/spec.html#names)
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct Name {
-    pub name: Arc<String>,
+    pub name: String,
     pub namespace: Option<String>,
     pub aliases: Option<Vec<String>>,
 }
@@ -196,7 +196,7 @@ impl Name {
     /// No `namespace` nor `aliases` will be defined.
     pub fn new(name: &str) -> Self {
         Self {
-            name: Arc::new(name.to_owned()),
+            name: name.to_owned(),
             namespace: None,
             aliases: None,
         }
@@ -219,7 +219,7 @@ impl Name {
             });
 
         Ok(Self {
-            name: Arc::new(name),
+            name,
             namespace,
             aliases,
         })

--- a/src/types.rs
+++ b/src/types.rs
@@ -99,7 +99,6 @@ pub enum Value {
     /// Avro Duration. An amount of time defined by months, days and milliseconds.
     Duration(Duration),
     /// Universally unique identifier.
-    /// Universally unique identifier.
     Uuid(Uuid),
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -65,6 +65,8 @@ pub enum Value {
     /// of its corresponding schema.
     /// This allows schema-less encoding, as well as schema resolution while
     /// reading values.
+    ///
+    /// The symbol's type is `Arc<String>` to allow shared ownership with the symbol in the schema.
     Enum(i32, Arc<String>),
     /// An `union` Avro value.
     Union(Box<Value>),

--- a/src/types.rs
+++ b/src/types.rs
@@ -202,7 +202,7 @@ pub struct Record<'a> {
     /// Ordered according to the fields in the schema given to create this
     /// `Record` object. Any unset field defaults to `Value::Null`.
     pub fields: Vec<(Arc<String>, Value)>,
-    schema_lookup: &'a HashMap<String, usize>,
+    lookup: &'a HashMap<String, usize>,
 }
 
 impl<'a> Record<'a> {
@@ -210,17 +210,13 @@ impl<'a> Record<'a> {
     ///
     /// If the `Schema` is not a `Schema::Record` variant, `None` will be returned.
     pub fn new(schema: &'a Schema) -> Option<Self> {
-        match *schema {
-            Schema::Record {
-                fields: ref schema_fields,
-                lookup: ref schema_lookup,
-                ..
-            } => Some(Self {
-                fields: schema_fields
+        match schema {
+            Schema::Record { fields, lookup, .. } => Some(Self {
+                fields: fields
                     .iter()
                     .map(|field| (field.name.clone(), Value::Null))
                     .collect(),
-                schema_lookup,
+                lookup,
             }),
             _ => None,
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -231,7 +231,7 @@ impl<'a> Record<'a> {
     where
         V: ToAvro,
     {
-        if let Some(&position) = self.schema_lookup.get(field) {
+        if let Some(&position) = self.lookup.get(field) {
             self.fields[position].1 = value.avro()
         }
     }


### PR DESCRIPTION
This PR adds shared ownership of two different `String` instances that were being cloned
for every row.

Note that this is a user-facing breaking change.

Initially I tried using `std::borrow::Cow`, but this has a number of downsides
that I thought were significant enough that implementing shared fields using
`Cow` didn't seem worth it.

1. Using `Cow` forces references to be used everywhere in the
   user-facing API (except where they can be elided, which isn't many places).
1. Using `Cow` ultimately filters down into the `Iterator` implementation, where, using lifetimes
   the deserialized `Value` now has a lifetime that is tied to the iterator. This is best handled by
   GATs (generic associated types) which are not fully implemented in the
   langauge last I checked (a few months ago).

`Rc` was suggested in #89, but `Rc`s are untenable because `Schema` is `Sync`
and therefore all variants must be sync.

The remaining approach is to use `Arc`.

The first `Arc`-ified `Value` variant is `Enum`, where the symbol in
`Value::Enum` is now shared with the symbols `Vec` in the schema.

The second thing that I `Arc`-ified, and the place I was expecting a fairly
large bang for my buck were the field names in `Schema::Record`. The field names in `Value::Record`
are now shared with those of `Schema::Record`.

I'd like for this to close #89, but so far the benchmark suite is only showing
a 40% improvement in the best case. I'm going to tinker around a bit and make
sure that there's nothing else to be done here.