### PR TITLE
Make writer.into_inner() call flush() and return a Result

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,10 @@ record.put("b", "foo");
 // schema validation happens here
 writer.append(record).unwrap();
 
-// flushing makes sure that all data gets encoded
-writer.flush().unwrap();
-
 // this is how to get back the resulting avro bytecode
-let encoded = writer.into_inner();
+// this performs a flush operation to make sure data has been written, so it can fail
+// you can also call `writer.flush()` yourself without consuming the writer
+let encoded = writer.into_inner().unwrap();
 ```
 
 The vast majority of the times, schemas tend to define a record as a top-level container
@@ -168,10 +167,9 @@ let test = Test {
 // schema validation happens here
 writer.append_ser(test).unwrap();
 
-// flushing makes sure that all data gets encoded
-writer.flush().unwrap();
-
 // this is how to get back the resulting avro bytecode
+// this performs a flush operation to make sure data is written, so it can fail
+// you can also call `writer.flush()` yourself without consuming the writer
 let encoded = writer.into_inner();
 ```
 
@@ -340,9 +338,7 @@ fn main() -> Result<(), Error> {
 
     writer.append_ser(test)?;
 
-    writer.flush()?;
-
-    let input = writer.into_inner();
+    let input = writer.into_inner()?;
     let reader = Reader::with_schema(&schema, &input[..])?;
 
     for record in reader {
@@ -457,9 +453,8 @@ fn main() -> Result<(), Error> {
     record.put("duration", Duration::new(Months::new(6), Days::new(7), Millis::new(8)));
 
     writer.append(record)?;
-    writer.flush()?;
 
-    let input = writer.into_inner();
+    let input = writer.into_inner()?;
     let reader = Reader::with_schema(&schema, &input[..])?;
 
     for record in reader {

--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -162,7 +162,7 @@ fn make_records(record: Value, count: usize) -> Vec<Value> {
 fn write(schema: &Schema, records: &[Value]) -> Vec<u8> {
     let mut writer = Writer::new(&schema, Vec::new());
     writer.extend_from_slice(records).unwrap();
-    writer.into_inner()
+    writer.into_inner().unwrap()
 }
 
 fn read(schema: &Schema, bytes: &[u8]) {

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -39,7 +39,7 @@ fn benchmark(schema: &Schema, record: &Value, s: &str, count: usize, runs: usize
         let duration = Instant::now().duration_since(start);
         durations.push(duration);
 
-        bytes = Some(writer.into_inner());
+        bytes = Some(writer.into_inner().unwrap());
     }
 
     let total_duration_write = durations.into_iter().fold(0u64, |a, b| a + nanos(b));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,11 +129,10 @@
 //! // schema validation happens here
 //! writer.append(record).unwrap();
 //!
-//! // flushing makes sure that all data gets encoded
-//! writer.flush().unwrap();
-//!
 //! // this is how to get back the resulting avro bytecode
-//! let encoded = writer.into_inner();
+//! // this performs a flush operation to make sure data has been written, so it can fail
+//! // you can also call `writer.flush()` yourself without consuming the writer
+//! let encoded = writer.into_inner().unwrap();
 //! ```
 //!
 //! The vast majority of the times, schemas tend to define a record as a top-level container
@@ -186,10 +185,9 @@
 //! // schema validation happens here
 //! writer.append_ser(test).unwrap();
 //!
-//! // flushing makes sure that all data gets encoded
-//! writer.flush().unwrap();
-//!
 //! // this is how to get back the resulting avro bytecode
+//! // this performs a flush operation to make sure data is written, so it can fail
+//! // you can also call `writer.flush()` yourself without consuming the writer
 //! let encoded = writer.into_inner();
 //! ```
 //!
@@ -261,8 +259,7 @@
 //! # record.put("a", 27i64);
 //! # record.put("b", "foo");
 //! # writer.append(record).unwrap();
-//! # writer.flush().unwrap();
-//! # let input = writer.into_inner();
+//! # let input = writer.into_inner().unwrap();
 //! // reader creation can fail in case the input to read from is not Avro-compatible or malformed
 //! let reader = Reader::new(&input[..]).unwrap();
 //! ```
@@ -291,8 +288,7 @@
 //! # record.put("a", 27i64);
 //! # record.put("b", "foo");
 //! # writer.append(record).unwrap();
-//! # writer.flush().unwrap();
-//! # let input = writer.into_inner();
+//! # let input = writer.into_inner().unwrap();
 //!
 //! let reader_raw_schema = r#"
 //!     {
@@ -352,8 +348,7 @@
 //! # record.put("a", 27i64);
 //! # record.put("b", "foo");
 //! # writer.append(record).unwrap();
-//! # writer.flush().unwrap();
-//! # let input = writer.into_inner();
+//! # let input = writer.into_inner().unwrap();
 //! let reader = Reader::new(&input[..]).unwrap();
 //!
 //! // value is a Result  of an Avro Value in case the read operation fails
@@ -399,8 +394,7 @@
 //! #     b: "foo".to_owned(),
 //! # };
 //! # writer.append_ser(test).unwrap();
-//! # writer.flush().unwrap();
-//! # let input = writer.into_inner();
+//! # let input = writer.into_inner().unwrap();
 //! let reader = Reader::new(&input[..]).unwrap();
 //!
 //! // value is a Result in case the read operation fails
@@ -456,9 +450,7 @@
 //!
 //!     writer.append_ser(test)?;
 //!
-//!     writer.flush()?;
-//!
-//!     let input = writer.into_inner();
+//!     let input = writer.into_inner()?;
 //!     let reader = Reader::with_schema(&schema, &input[..])?;
 //!
 //!     for record in reader {
@@ -573,9 +565,8 @@
 //!     record.put("duration", Duration::new(Months::new(6), Days::new(7), Millis::new(8)));
 //!
 //!     writer.append(record)?;
-//!     writer.flush()?;
 //!
-//!     let input = writer.into_inner();
+//!     let input = writer.into_inner()?;
 //!     let reader = Reader::with_schema(&schema, &input[..])?;
 //!
 //!     for record in reader {
@@ -756,8 +747,7 @@ mod tests {
         record.put("a", 27i64);
         record.put("b", "foo");
         writer.append(record).unwrap();
-        writer.flush().unwrap();
-        let input = writer.into_inner();
+        let input = writer.into_inner().unwrap();
         let mut reader = Reader::with_schema(&reader_schema, &input[..]).unwrap();
         assert_eq!(
             reader.next().unwrap().unwrap(),
@@ -799,8 +789,7 @@ mod tests {
         record.put("b", "foo");
         record.put("c", "clubs");
         writer.append(record).unwrap();
-        writer.flush().unwrap();
-        let input = writer.into_inner();
+        let input = writer.into_inner().unwrap();
         let mut reader = Reader::with_schema(&schema, &input[..]).unwrap();
         assert_eq!(
             reader.next().unwrap().unwrap(),
@@ -862,8 +851,7 @@ mod tests {
         record.put("b", "foo");
         record.put("c", "clubs");
         writer.append(record).unwrap();
-        writer.flush().unwrap();
-        let input = writer.into_inner();
+        let input = writer.into_inner().unwrap();
         let mut reader = Reader::with_schema(&reader_schema, &input[..]).unwrap();
         assert!(reader.next().unwrap().is_err());
         assert!(reader.next().is_none());
@@ -898,8 +886,7 @@ mod tests {
         record.put("b", "foo");
         record.put("c", "clubs");
         writer.append(record).unwrap();
-        writer.flush().unwrap();
-        let input = writer.into_inner();
+        let input = writer.into_inner().unwrap();
         let mut reader = Reader::new(&input[..]).unwrap();
         assert_eq!(
             reader.next().unwrap().unwrap(),

--- a/src/schema_compatibility.rs
+++ b/src/schema_compatibility.rs
@@ -422,9 +422,8 @@ mod tests {
         union_schema(vec![])
     }
 
-    fn null_union_schema() -> Schema {
-        union_schema(vec![Schema::Null])
-    }
+    // unused
+    // fn null_union_schema() -> Schema { union_schema(vec![Schema::Null]) }
 
     fn int_union_schema() -> Schema {
         union_schema(vec![Schema::Int])
@@ -755,17 +754,20 @@ mod tests {
         assert!(SchemaCompatibility::can_read(&enum_schema1, &enum_schema2));
     }
 
-    fn point_2d_schema() -> Schema {
-        Schema::parse_str(
-            r#"
-      {"type":"record", "name":"Point2D", "fields":[
-        {"name":"x", "type":"double"},
-        {"name":"y", "type":"double"}
-      ]}
-    "#,
-        )
-        .unwrap()
-    }
+    // unused
+    /*
+        fn point_2d_schema() -> Schema {
+            Schema::parse_str(
+                r#"
+          {"type":"record", "name":"Point2D", "fields":[
+            {"name":"x", "type":"double"},
+            {"name":"y", "type":"double"}
+          ]}
+        "#,
+            )
+            .unwrap()
+        }
+    */
 
     fn point_2d_fullname_schema() -> Schema {
         Schema::parse_str(
@@ -792,31 +794,34 @@ mod tests {
         .unwrap()
     }
 
-    fn point_3d_schema() -> Schema {
-        Schema::parse_str(
-            r#"
-      {"type":"record", "name":"Point3D", "fields":[
-        {"name":"x", "type":"double"},
-        {"name":"y", "type":"double"},
-        {"name":"z", "type":"double", "default": 0.0}
-      ]}
-    "#,
-        )
-        .unwrap()
-    }
+    // unused
+    /*
+        fn point_3d_schema() -> Schema {
+            Schema::parse_str(
+                r#"
+          {"type":"record", "name":"Point3D", "fields":[
+            {"name":"x", "type":"double"},
+            {"name":"y", "type":"double"},
+            {"name":"z", "type":"double", "default": 0.0}
+          ]}
+        "#,
+            )
+            .unwrap()
+        }
 
-    fn point_3d_match_name_schema() -> Schema {
-        Schema::parse_str(
-            r#"
-      {"type":"record", "name":"Point", "fields":[
-        {"name":"x", "type":"double"},
-        {"name":"y", "type":"double"},
-        {"name":"z", "type":"double", "default": 0.0}
-      ]}
-    "#,
-        )
-        .unwrap()
-    }
+        fn point_3d_match_name_schema() -> Schema {
+            Schema::parse_str(
+                r#"
+          {"type":"record", "name":"Point", "fields":[
+            {"name":"x", "type":"double"},
+            {"name":"y", "type":"double"},
+            {"name":"z", "type":"double", "default": 0.0}
+          ]}
+        "#,
+            )
+            .unwrap()
+        }
+    */
 
     #[test]
     fn test_union_resolution_no_structure_match() {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -258,10 +258,11 @@ impl<'a, W: Write> Writer<'a, W> {
 
     /// Return what the `Writer` is writing to, consuming the `Writer` itself.
     ///
-    /// **NOTE** This function doesn't guarantee that everything gets written before consuming the
-    /// buffer. Please call [`flush`](struct.Writer.html#method.flush) before.
-    pub fn into_inner(self) -> W {
-        self.writer
+    /// **NOTE** This function forces the written data to be flushed (an implicit
+    /// call to [`flush`](struct.Writer.html#method.flush) is performed).
+    pub fn into_inner(mut self) -> Result<W, Error> {
+        self.flush()?;
+        Ok(self.writer)
     }
 
     /// Generate and append synchronization marker to the payload.
@@ -559,7 +560,7 @@ mod tests {
         let n1 = writer.append(record.clone()).unwrap();
         let n2 = writer.append(record.clone()).unwrap();
         let n3 = writer.flush().unwrap();
-        let result = writer.into_inner();
+        let result = writer.into_inner().unwrap();
 
         assert_eq!(n1 + n2 + n3, result.len());
 
@@ -592,7 +593,7 @@ mod tests {
 
         let n1 = writer.extend(records.into_iter()).unwrap();
         let n2 = writer.flush().unwrap();
-        let result = writer.into_inner();
+        let result = writer.into_inner().unwrap();
 
         assert_eq!(n1 + n2, result.len());
 
@@ -630,7 +631,7 @@ mod tests {
 
         let n1 = writer.append_ser(record).unwrap();
         let n2 = writer.flush().unwrap();
-        let result = writer.into_inner();
+        let result = writer.into_inner().unwrap();
 
         assert_eq!(n1 + n2, result.len());
 
@@ -663,7 +664,7 @@ mod tests {
 
         let n1 = writer.extend_ser(records.into_iter()).unwrap();
         let n2 = writer.flush().unwrap();
-        let result = writer.into_inner();
+        let result = writer.into_inner().unwrap();
 
         assert_eq!(n1 + n2, result.len());
 
@@ -704,7 +705,7 @@ mod tests {
         let n1 = writer.append(record.clone()).unwrap();
         let n2 = writer.append(record.clone()).unwrap();
         let n3 = writer.flush().unwrap();
-        let result = writer.into_inner();
+        let result = writer.into_inner().unwrap();
 
         assert_eq!(n1 + n2 + n3, result.len());
 
@@ -779,7 +780,7 @@ mod tests {
         let n1 = writer.append(record1).unwrap();
         let n2 = writer.append(record2).unwrap();
         let n3 = writer.flush().unwrap();
-        let result = writer.into_inner();
+        let result = writer.into_inner().unwrap();
 
         assert_eq!(n1 + n2 + n3, result.len());
 


### PR DESCRIPTION
This is in line with other buffer implementations out there, like
https://doc.rust-lang.org/std/io/struct.BufWriter.html#method.into_inner