### PR TITLE
Bump digest library to 0.9 and its dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ harness = false
 [dependencies]
 byteorder = "1.0.0"
 crc = { version = "1.3.0", optional = true }
-digest = "0.8"
+digest = "0.9"
 failure = "0.1.5"
 libflate = "0.1"
 num-bigint = "0.2.6"
@@ -49,7 +49,7 @@ uuid = { version = "0.8.1", features = ["v4"] }
 zerocopy = "0.3.0"
 
 [dev-dependencies]
-md-5 = "0.8"
+md-5 = "0.9"
 lazy_static = "^1.1"
-sha2 = "0.8"
+sha2 = "0.9"
 criterion = "0.3.1"

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -455,9 +455,9 @@ impl Schema {
     /// https://avro.apache.org/docs/current/spec.html#schema_fingerprints
     pub fn fingerprint<D: Digest>(&self) -> SchemaFingerprint {
         let mut d = D::new();
-        d.input(self.canonical_form());
+        d.update(self.canonical_form());
         SchemaFingerprint {
-            bytes: d.result().to_vec(),
+            bytes: d.finalize().to_vec(),
         }
     }
 


### PR DESCRIPTION
This also includes a bump for sha2 library. As it stands, the trait changed,
meaning this will actually be a breaking change for anyone using the fingerprint
functionality of `avro-rs`.