### PR TITLE
Export fn encode::encode(..)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -694,6 +694,7 @@ pub use crate::codec::Codec;
 pub use crate::de::{from_value, Error as DeError};
 pub use crate::decimal::Decimal;
 pub use crate::duration::{Days, Duration, Millis, Months};
+pub use crate::encode::encode;
 pub use crate::reader::{from_avro_datum, Reader};
 pub use crate::schema::{ParseSchemaError, Schema};
 pub use crate::ser::{to_value, Error as SerError};


### PR DESCRIPTION
My use case requires me to suspend and restart encoding of Avro containers. Exposing the low-level encode function allows for encoding Avro values without relying on the `Writer`, which offers no way to "resume" writing but always writes out the schema. 

It's a somewhat manual process but until we know better abstractions for the problem we can add those. 