### PR TITLE
Move from failure to thiserror

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@
     -   id: rust-clippy
         name: Rust clippy
         description: Run cargo clippy on files included in the commit. clippy should be installed before-hand.
-        entry: cargo clippy --all-features --all --
+        entry: cargo clippy --all-targets --all-features -- -Dclippy::all
         pass_filenames: false
         types: [file, rust]
         language: system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Introduced custom Error enum to replace all existing erroros
+- Swapped failure for thiserror
 
 ## [0.10.0] - 2020-05-31
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Introduced custom Error enum to replace all existing erroros
-- Swapped failure for thiserror
+- Introduce custom Error enum to replace all existing errors (backward-incompatible) (#135)
+- Swapped failure for thiserror (backward-incompatible) (#135)
+- Update digest crate and digest::Digest trait to 0.9 (backward-incompatible with digest::Digest 0.8) (#133)
+- Replace some manual from_str implementations with strum (#136)
+
+## Deprecated
+- Deprecate ToAvro in favor of From<T> for Value implementations (#137)
 
 ## [0.10.0] - 2020-05-31
 ### Changed
-- Writer::into_inner() now calls flush() and returns a Result
+- Writer::into_inner() now calls flush() and returns a Result (backward-incompatible)
 
 ### Added
-- Add utilited for schema compatibility check
+- Add utility for schema compatibility check
 
 ## [0.9.1] - 2020-05-02
 ### Changed
@@ -66,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.0]- 2018-08-11
 ### Added
-- impl Send+Sync for Schema (non-backwards compatible)
+- impl Send+Sync for Schema (backwards-incompatible)
 
 ## [0.5.0] - 2018-08-06
 ### Added
@@ -79,7 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.1] - 2018-06-17
 ### Changed
-- Implememented clippy suggestions
+- Implemented clippy suggestions
 
 ## [0.4.0] - 2018-06-17
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ harness = false
 byteorder = "1.0.0"
 crc = { version = "1.3.0", optional = true }
 digest = "0.9"
-failure = "0.1.5"
 libflate = "0.1"
 num-bigint = "0.2.6"
 rand = "0.4"
@@ -44,6 +43,7 @@ serde = { version = "1.0", features = ["derive"] }
 snap = { version = "0.2.3", optional = true }
 strum = "0.18.0"
 strum_macros = "0.18.0"
+thiserror = "1.0"
 typed-builder = "0.5.1"
 uuid = { version = "0.8.1", features = ["v4"] }
 zerocopy = "0.3.0"

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ version = "x.y"
 features = ["snappy"]
 ```
 
+## Upgrading to a newer minor version
+
+The library is still in beta, so there might be backward-incompatible changes between minor
+versions. If you have troubles upgrading, check the [version upgrade guide](migration_guide.md).
+
 ## Defining a schema
 
 An Avro data cannot exist without an Avro schema. Schemas **must** be used while writing and
@@ -297,8 +302,7 @@ The following is an example of how to combine everything showed so far and it is
 quick reference of the library interface:
 
 ```rust
-use avro_rs::{Codec, Reader, Schema, Writer, from_value, types::Record};
-use failure::Error;
+use avro_rs::{Codec, Reader, Schema, Writer, from_value, types::Record, Error};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -363,10 +367,9 @@ Note that the on-disk representation is identical to the underlying primitive/co
 ```rust
 use avro_rs::{
     types::Record, types::Value, Codec, Days, Decimal, Duration, Millis, Months, Reader, Schema,
-    Writer,
+    Writer, Error,
 };
 use num_bigint::ToBigInt;
-use failure::Error;
 
 fn main() -> Result<(), Error> {
     let raw_schema = r#"
@@ -476,8 +479,7 @@ Note: Rabin fingerprinting is NOT SUPPORTED yet.
 An example of fingerprinting for the supported fingerprints:
 
 ```rust
-use avro_rs::Schema;
-use failure::Error;
+use avro_rs::{Schema, Error};
 use md5::Md5;
 use sha2::Sha256;
 
@@ -572,4 +574,5 @@ Everyone is encouraged to contribute! You can contribute by forking the GitHub r
 All contributions will be licensed under [MIT License](https://github.com/flavray/avro-rs/blob/master/LICENSE).
 
 Please consider adding documentation, tests and a line for your change under the Unreleased section in the [CHANGELOG](https://github.com/flavray/avro-rs/blob/master/CHANGELOG.md).
+If you introduce a backward-incompatible change, please consider adding instruction to migrate in the [Migration Guide](migration_guide.md)
 If you modify the crate documentation in `lib.rs`, run `make readme` to sync the README file.

--- a/README.tpl
+++ b/README.tpl
@@ -16,4 +16,5 @@ Everyone is encouraged to contribute! You can contribute by forking the GitHub r
 All contributions will be licensed under [MIT License](https://github.com/flavray/avro-rs/blob/master/LICENSE).
 
 Please consider adding documentation, tests and a line for your change under the Unreleased section in the [CHANGELOG](https://github.com/flavray/avro-rs/blob/master/CHANGELOG.md).
+If you introduce a backward-incompatible change, please consider adding instruction to migrate in the [Migration Guide](migration_guide.md)
 If you modify the crate documentation in `lib.rs`, run `make readme` to sync the README file.

--- a/examples/to_value.rs
+++ b/examples/to_value.rs
@@ -1,4 +1,4 @@
-use avro_rs::{to_value, AvroError};
+use avro_rs::{to_value, Error};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -7,7 +7,7 @@ struct Test {
     b: String,
 }
 
-fn main() -> Result<(), AvroError> {
+fn main() -> Result<(), Error> {
     let test = Test {
         a: 27,
         b: "foo".to_owned(),

--- a/examples/to_value.rs
+++ b/examples/to_value.rs
@@ -1,5 +1,4 @@
-use avro_rs::to_value;
-use failure::Error;
+use avro_rs::{to_value, AvroError};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -8,7 +7,7 @@ struct Test {
     b: String,
 }
 
-fn main() -> Result<(), Error> {
+fn main() -> Result<(), AvroError> {
     let test = Test {
         a: 27,
         b: "foo".to_owned(),

--- a/migration_guide.md
+++ b/migration_guide.md
@@ -1,0 +1,79 @@
+# Migration Guide
+## Unreleased
+- A custom `Error` enum has been introduced to replace all existing errors and
+  the `failure` crate has been replaced by `thiserror`. 
+
+  This means that all public functions returning `Result<T, failure::Error>`
+  will now return `Result<T, avro::Error>` and that you can pattern match on
+  `Error` variants if you want to gather more information about the error.
+  
+  For example, code that used to be like this:
+  ```rust
+  match decoded {
+      Ok(msg) => Ok(msg.to_string()),
+      Err(ref e) => match e.downcast_ref::<SchemaResolutionError>() {
+          Some(_) => Ok("default".to_string()),
+          None => Err(format!("Unexpected error: {}", e)),
+      },
+  }
+  ```
+  
+  now becomes:
+  ```rust
+  match decoded {
+      Ok(msg) => Ok(msg.to_string()),
+      Err(Error::SchemaResolution(_)) => Ok("default".to_string()),
+      Err(ref e) => Err(format!("Unexpected error: {}", e)),
+  }
+  ```
+  
+  Please note that all instances of:
+  - `DecodeError`
+  - `ValidationError`
+  - `DeError`
+  - `SerError`
+  - `ParseSchemaError`
+  - `SchemaResolutionError`
+  
+  must be replaced by `Error`.
+
+- The `ToAvro` trait has been deprecated in favor of `From<T>` for `Value` implementations.
+
+  Code like the following:
+  ```rust
+  use crate::types::{Record, ToAvro, Value};
+  
+  let expected: Value = record.avro();
+  ```
+  
+  should be updated to:
+  
+  ```rust
+  use crate::types::{Record, Value};
+   
+  let expected: Value = record.into(); 
+  ```
+
+  Using the `ToAvro` trait will result in a deprecation warning. The trait will
+  be removed in future versions.
+  
+- The `digest` crate has been updated to version `0.9`. If you were using the
+  `digest::Digest` trait from version `0.8`, you must update to the one defined
+  in `0.9`.
+
+## 0.10.0
+- `Writer::into_inner()` now calls `flush()` and returns a `Result`.
+
+  This means that code like
+  ```rust
+  writer.append_ser(test)?;
+  writer.flush()?;
+  let input = writer.into_inner();
+  ```
+  
+  can be simplified into
+  ```rust
+  writer.append_ser(test)?;
+  let input = writer.into_inner()?; 
+  ```
+  There is no harm in leaving old calls to `flush()` around.

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -47,7 +47,7 @@ impl FromStr for Codec {
             "deflate" => Ok(Codec::Deflate),
             #[cfg(feature = "snappy")]
             "snappy" => Ok(Codec::Snappy),
-            _ => Err(Error::Decode("unrecognized codec".to_string())),
+            _ => Err(Error::Codec(s.to_string())),
         }
     }
 }
@@ -104,10 +104,7 @@ impl Codec {
                 let actual_crc = crc::crc32::checksum_ieee(&decoded);
 
                 if expected_crc != actual_crc {
-                    return Err(Error::Decode(format!(
-                        "bad Snappy CRC32; expected {:x} but got {:x}",
-                        expected_crc, actual_crc
-                    )));
+                    return Err(Error::SnappyCrcError(expected_crc, actual_crc));
                 }
                 decoded
             }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -104,7 +104,10 @@ impl Codec {
                 let actual_crc = crc::crc32::checksum_ieee(&decoded);
 
                 if expected_crc != actual_crc {
-                    return Err(Error::SnappyCrcError(expected_crc, actual_crc));
+                    return Err(Error::SnappyCrcError {
+                        expected: expected_crc,
+                        found: actual_crc,
+                    });
                 }
                 decoded
             }

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1,4 +1,4 @@
-use failure::{Error, Fail};
+use crate::errors::AvroError;
 use num_bigint::BigInt;
 
 #[derive(Debug, Clone)]
@@ -15,38 +15,33 @@ impl PartialEq for Decimal {
     }
 }
 
-#[derive(Fail, Debug)]
-#[fail(display = "Decimal sign extension error: {}", _0)]
-pub struct SignExtendError(&'static str, usize, usize);
-
 impl Decimal {
     pub(crate) fn len(&self) -> usize {
         self.len
     }
 
-    fn to_vec(&self) -> Result<Vec<u8>, Error> {
+    fn to_vec(&self) -> Result<Vec<u8>, AvroError> {
         self.to_sign_extended_bytes_with_len(self.len)
     }
 
-    pub(crate) fn to_sign_extended_bytes_with_len(&self, len: usize) -> Result<Vec<u8>, Error> {
+    pub(crate) fn to_sign_extended_bytes_with_len(&self, len: usize) -> Result<Vec<u8>, AvroError> {
         let sign_byte = 0xFF * u8::from(self.value.sign() == num_bigint::Sign::Minus);
         let mut decimal_bytes = vec![sign_byte; len];
         let raw_bytes = self.value.to_signed_bytes_be();
         let num_raw_bytes = raw_bytes.len();
-        let start_byte_index = len.checked_sub(num_raw_bytes).ok_or_else(|| {
-            SignExtendError(
-                "number of bytes requested for sign extension {} is less than the number of bytes needed to decode {}",
-                len,
-                num_raw_bytes,
-            )
-        })?;
+        let start_byte_index =
+            len.checked_sub(num_raw_bytes)
+                .ok_or_else(|| AvroError::SignExtendError {
+                    requested: len,
+                    needed: num_raw_bytes,
+                })?;
         decimal_bytes[start_byte_index..].copy_from_slice(&raw_bytes);
         Ok(decimal_bytes)
     }
 }
 
 impl std::convert::TryFrom<&Decimal> for Vec<u8> {
-    type Error = Error;
+    type Error = AvroError;
 
     fn try_from(decimal: &Decimal) -> Result<Self, Self::Error> {
         decimal.to_vec()

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1,4 +1,4 @@
-use crate::errors::AvroError;
+use crate::errors::{AvroResult, Error};
 use num_bigint::BigInt;
 
 #[derive(Debug, Clone)]
@@ -20,28 +20,28 @@ impl Decimal {
         self.len
     }
 
-    fn to_vec(&self) -> Result<Vec<u8>, AvroError> {
+    fn to_vec(&self) -> AvroResult<Vec<u8>> {
         self.to_sign_extended_bytes_with_len(self.len)
     }
 
-    pub(crate) fn to_sign_extended_bytes_with_len(&self, len: usize) -> Result<Vec<u8>, AvroError> {
+    pub(crate) fn to_sign_extended_bytes_with_len(&self, len: usize) -> AvroResult<Vec<u8>> {
         let sign_byte = 0xFF * u8::from(self.value.sign() == num_bigint::Sign::Minus);
         let mut decimal_bytes = vec![sign_byte; len];
         let raw_bytes = self.value.to_signed_bytes_be();
         let num_raw_bytes = raw_bytes.len();
-        let start_byte_index =
-            len.checked_sub(num_raw_bytes)
-                .ok_or_else(|| AvroError::SignExtendError {
-                    requested: len,
-                    needed: num_raw_bytes,
-                })?;
+        let start_byte_index = len
+            .checked_sub(num_raw_bytes)
+            .ok_or_else(|| Error::SignExtend {
+                requested: len,
+                needed: num_raw_bytes,
+            })?;
         decimal_bytes[start_byte_index..].copy_from_slice(&raw_bytes);
         Ok(decimal_bytes)
     }
 }
 
 impl std::convert::TryFrom<&Decimal> for Vec<u8> {
-    type Error = AvroError;
+    type Error = Error;
 
     fn try_from(decimal: &Decimal) -> Result<Self, Self::Error> {
         decimal.to_vec()

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -2,32 +2,32 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::str::FromStr;
 
-use failure::Error;
 use uuid::Uuid;
 
 use crate::decimal::Decimal;
 use crate::duration::Duration;
+use crate::errors::AvroError;
 use crate::schema::Schema;
 use crate::types::Value;
-use crate::util::{safe_len, zag_i32, zag_i64, DecodeError};
+use crate::util::{safe_len, zag_i32, zag_i64};
 
 #[inline]
-fn decode_long<R: Read>(reader: &mut R) -> Result<Value, Error> {
+fn decode_long<R: Read>(reader: &mut R) -> Result<Value, AvroError> {
     zag_i64(reader).map(Value::Long)
 }
 
 #[inline]
-fn decode_int<R: Read>(reader: &mut R) -> Result<Value, Error> {
+fn decode_int<R: Read>(reader: &mut R) -> Result<Value, AvroError> {
     zag_i32(reader).map(Value::Int)
 }
 
 #[inline]
-fn decode_len<R: Read>(reader: &mut R) -> Result<usize, Error> {
+fn decode_len<R: Read>(reader: &mut R) -> Result<usize, AvroError> {
     zag_i64(reader).and_then(|len| safe_len(len as usize))
 }
 
 /// Decode a `Value` from avro format given its `Schema`.
-pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> {
+pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, AvroError> {
     match *schema {
         Schema::Null => Ok(Value::Null),
         Schema::Boolean => {
@@ -37,32 +37,34 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
             match buf[0] {
                 0u8 => Ok(Value::Boolean(false)),
                 1u8 => Ok(Value::Boolean(true)),
-                _ => Err(DecodeError::new("not a bool").into()),
+                _ => Err(AvroError::DecodeError("not a bool".to_string())),
             }
         }
         Schema::Decimal { ref inner, .. } => match **inner {
             Schema::Fixed { .. } => match decode(inner, reader)? {
                 Value::Fixed(_, bytes) => Ok(Value::Decimal(Decimal::from(bytes))),
-                _ => Err(DecodeError::new(
-                    "not a fixed value, required for decimal with fixed schema",
-                )
-                .into()),
+                _ => Err(AvroError::DecodeError(
+                    "not a fixed value, required for decimal with fixed schema".to_string(),
+                )),
             },
             Schema::Bytes => match decode(inner, reader)? {
                 Value::Bytes(bytes) => Ok(Value::Decimal(Decimal::from(bytes))),
-                _ => Err(DecodeError::new(
-                    "not a bytes value, required for decimal with bytes schema",
-                )
-                .into()),
+                _ => Err(AvroError::DecodeError(
+                    "not a bytes value, required for decimal with bytes schema".to_string(),
+                )),
             },
-            _ => Err(
-                DecodeError::new("not a fixed or bytes type, required for decimal schema").into(),
-            ),
+            _ => Err(AvroError::DecodeError(
+                "not a fixed or bytes type, required for decimal schema".to_string(),
+            )),
         },
         Schema::Uuid => Ok(Value::Uuid(Uuid::from_str(
             match decode(&Schema::String, reader)? {
                 Value::String(ref s) => s,
-                _ => return Err(DecodeError::new("not a string type, required for uuid").into()),
+                _ => {
+                    return Err(AvroError::DecodeError(
+                        "not a string type, required for uuid".to_string(),
+                    ))
+                }
             },
         )?)),
         Schema::Int => decode_int(reader),
@@ -100,7 +102,7 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
 
             String::from_utf8(buf)
                 .map(Value::String)
-                .map_err(|_| DecodeError::new("not a valid utf-8 string").into())
+                .map_err(|_| AvroError::DecodeError("not a valid utf-8 string".to_string()))
         }
         Schema::Fixed { size, .. } => {
             let mut buf = vec![0u8; size as usize];
@@ -153,7 +155,9 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
                         let value = decode(inner, reader)?;
                         items.insert(key, value);
                     } else {
-                        return Err(DecodeError::new("map key is not a string").into());
+                        return Err(AvroError::DecodeError(
+                            "map key is not a string".to_string(),
+                        ));
                     }
                 }
             }
@@ -165,7 +169,7 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
             let variants = inner.variants();
             let variant = variants
                 .get(index as usize)
-                .ok_or_else(|| DecodeError::new("Union index out of bounds"))?;
+                .ok_or_else(|| AvroError::DecodeError("Union index out of bounds".to_string()))?;
             let value = decode(variant, reader)?;
             Ok(Value::Union(Box::new(value)))
         }
@@ -184,10 +188,12 @@ pub fn decode<R: Read>(schema: &Schema, reader: &mut R) -> Result<Value, Error> 
                     let symbol = symbols[index as usize].clone();
                     Ok(Value::Enum(index, symbol))
                 } else {
-                    Err(DecodeError::new("enum symbol index out of bounds").into())
+                    Err(AvroError::DecodeError(
+                        "enum symbol index out of bounds".to_string(),
+                    ))
                 }
             } else {
-                Err(DecodeError::new("enum symbol not found").into())
+                Err(AvroError::DecodeError("enum symbol not found".to_string()))
             }
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,38 +2,41 @@ use crate::de;
 use crate::ser;
 use thiserror::Error;
 
+pub(crate) type AvroResult<T> = Result<T, Error>;
+
+#[non_exhaustive]
 #[derive(Error, Debug)]
 /// Error type returned from the library
-pub enum AvroError {
+pub enum Error {
     /// Represents all cases of `std::io::Error`
     #[error(transparent)]
-    IOError(#[from] std::io::Error),
+    IO(#[from] std::io::Error),
 
     /// Describes errors happened while decoding Avro data (except for `std::io::Error`)
     #[error("Decoding error: {0}")]
-    DecodeError(String),
+    Decode(String),
 
     /// Describes errors happened while parsing Avro schemas
     #[error("Failed to parse schema: {0}")]
-    ParseSchemaError(String),
+    Parse(String),
 
     /// Describes errors happened while performing schema resolution on Avro data.
     #[error("Schema resolution error: {0}")]
-    SchemaResolutionError(String),
+    SchemaResolution(String),
 
     /// Describes errors happened while validating Avro data.
     #[error("Validation error: {0}")]
-    ValidationError(String),
+    Validation(String),
 
     // TODO: figure out how to move the implementation of this error here
     /// Describes errors that could be encountered while serializing data
     #[error(transparent)]
-    SerError(#[from] ser::Error),
+    Ser(#[from] ser::Error),
 
     // TODO: figure out how to move the implementation of this error here
     /// Describes errors that could be encountered while serializing data
     #[error(transparent)]
-    DeError(#[from] de::Error),
+    De(#[from] de::Error),
 
     // TODO: merge with SerError somehow?
     // /// Represents all cases of `serde::ser::Error`
@@ -41,33 +44,33 @@ pub enum AvroError {
     //SerdeSerError(#[from] serde::ser::Error),
     /// Describes errors happened trying to allocate too many bytes
     #[error("Unable to allocate {desired} bytes (maximum allowed: {maximum})")]
-    MemoryAllocationError { desired: usize, maximum: usize },
+    MemoryAllocation { desired: usize, maximum: usize },
 
     /// Represents all cases of `uuid::Error`
     #[error(transparent)]
-    UuidError(#[from] uuid::Error),
+    Uuid(#[from] uuid::Error),
 
     /// Describe a specific error happening with decimal representation
     #[error("Number of bytes requested for decimal sign extension {requested} is less than the number of bytes needed to decode {needed}")]
-    SignExtendError { requested: usize, needed: usize },
+    SignExtend { requested: usize, needed: usize },
 
     // TODO: Should this be wrapped by ParseSchemaError somehow?
     /// Represents all cases of `std::num::TryFromIntError`
     #[error(transparent)]
-    TryFromIntError(#[from] std::num::TryFromIntError),
+    TryFromInt(#[from] std::num::TryFromIntError),
 
     // TODO: Should this be wrapped by ParseSchemaError somehow?
     /// Represents all cases of `serde_json::Error`
     #[error(transparent)]
-    JSONError(#[from] serde_json::Error),
+    JSON(#[from] serde_json::Error),
 
     // TODO: Should this be wrapped by SchemaResolutionError somehow?
     /// Represents all cases of `std::string::FromUtf8Error`
     #[error(transparent)]
-    FromUtf8Error(#[from] std::string::FromUtf8Error),
+    FromUtf8(#[from] std::string::FromUtf8Error),
 
     /// Represents errors coming from Snappy encoding and decoding
     #[cfg(feature = "snappy")]
     #[error(transparent)]
-    SnappyError(#[from] snap::Error),
+    Snappy(#[from] snap::Error),
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,73 @@
+use crate::de;
+use crate::ser;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+/// Error type returned from the library
+pub enum AvroError {
+    /// Represents all cases of `std::io::Error`
+    #[error(transparent)]
+    IOError(#[from] std::io::Error),
+
+    /// Describes errors happened while decoding Avro data (except for `std::io::Error`)
+    #[error("Decoding error: {0}")]
+    DecodeError(String),
+
+    /// Describes errors happened while parsing Avro schemas
+    #[error("Failed to parse schema: {0}")]
+    ParseSchemaError(String),
+
+    /// Describes errors happened while performing schema resolution on Avro data.
+    #[error("Schema resolution error: {0}")]
+    SchemaResolutionError(String),
+
+    /// Describes errors happened while validating Avro data.
+    #[error("Validation error: {0}")]
+    ValidationError(String),
+
+    // TODO: figure out how to move the implementation of this error here
+    /// Describes errors that could be encountered while serializing data
+    #[error(transparent)]
+    SerError(#[from] ser::Error),
+
+    // TODO: figure out how to move the implementation of this error here
+    /// Describes errors that could be encountered while serializing data
+    #[error(transparent)]
+    DeError(#[from] de::Error),
+
+    // TODO: merge with SerError somehow?
+    // /// Represents all cases of `serde::ser::Error`
+    //#[error(transparent)]
+    //SerdeSerError(#[from] serde::ser::Error),
+    /// Describes errors happened trying to allocate too many bytes
+    #[error("Unable to allocate {desired} bytes (maximum allowed: {maximum})")]
+    MemoryAllocationError { desired: usize, maximum: usize },
+
+    /// Represents all cases of `uuid::Error`
+    #[error(transparent)]
+    UuidError(#[from] uuid::Error),
+
+    /// Describe a specific error happening with decimal representation
+    #[error("Number of bytes requested for decimal sign extension {requested} is less than the number of bytes needed to decode {needed}")]
+    SignExtendError { requested: usize, needed: usize },
+
+    // TODO: Should this be wrapped by ParseSchemaError somehow?
+    /// Represents all cases of `std::num::TryFromIntError`
+    #[error(transparent)]
+    TryFromIntError(#[from] std::num::TryFromIntError),
+
+    // TODO: Should this be wrapped by ParseSchemaError somehow?
+    /// Represents all cases of `serde_json::Error`
+    #[error(transparent)]
+    JSONError(#[from] serde_json::Error),
+
+    // TODO: Should this be wrapped by SchemaResolutionError somehow?
+    /// Represents all cases of `std::string::FromUtf8Error`
+    #[error(transparent)]
+    FromUtf8Error(#[from] std::string::FromUtf8Error),
+
+    /// Represents errors coming from Snappy encoding and decoding
+    #[cfg(feature = "snappy")]
+    #[error(transparent)]
+    SnappyError(#[from] snap::Error),
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,5 +1,3 @@
-use crate::de;
-use crate::ser;
 use thiserror::Error;
 
 pub(crate) type AvroResult<T> = Result<T, Error>;
@@ -13,39 +11,35 @@ pub enum Error {
     IO(#[from] std::io::Error),
 
     /// Error due to unrecognized coded
-    #[error("Unrecognized codec: {0:?}")]
+    #[error("unrecognized codec: {0:?}")]
     Codec(String),
 
     /// Errors happened while decoding Avro data (except for `std::io::Error`)
-    #[error("Decoding error: {0}")]
+    #[error("decoding error: {0}")]
     Decode(String),
 
     /// Errors happened while parsing Avro schemas
-    #[error("Failed to parse schema: {0}")]
+    #[error("failed to parse schema: {0}")]
     Parse(String),
 
     /// Errors happened while performing schema resolution on Avro data
-    #[error("Schema resolution error: {0}")]
+    #[error("schema resolution error: {0}")]
     SchemaResolution(String),
 
     /// Errors happened while validating Avro data
-    #[error("Validation error: {0}")]
+    #[error("validation error: {0}")]
     Validation(String),
 
-    /// Errors that could be encountered while serializing data
-    #[error(transparent)]
-    Ser(#[from] ser::Error),
+    /// Errors that could be encountered while serializing data, implements `serde::ser::Error`
+    #[error("data serialization error: {0}")]
+    Ser(String),
 
-    /// Errors that could be encountered while serializing data
-    #[error(transparent)]
-    De(#[from] de::Error),
+    /// Errors that could be encountered while deserializing data, implements `serde::de::Error`
+    #[error("data deserialization error: {0}")]
+    De(String),
 
-    // TODO: merge with SerError somehow?
-    // /// All cases of `serde::ser::Error`
-    //#[error(transparent)]
-    //SerdeSerError(#[from] serde::ser::Error),
     /// Error happened trying to allocate too many bytes
-    #[error("Unable to allocate {desired} bytes (maximum allowed: {maximum})")]
+    #[error("unable to allocate {desired} bytes (maximum allowed: {maximum})")]
     MemoryAllocation { desired: usize, maximum: usize },
 
     /// All cases of `uuid::Error`
@@ -53,7 +47,7 @@ pub enum Error {
     Uuid(#[from] uuid::Error),
 
     /// Error happening with decimal representation
-    #[error("Number of bytes requested for decimal sign extension {requested} is less than the number of bytes needed to decode {needed}")]
+    #[error("number of bytes requested for decimal sign extension {requested} is less than the number of bytes needed to decode {needed}")]
     SignExtend { requested: usize, needed: usize },
 
     /// All cases of `std::num::TryFromIntError`
@@ -69,7 +63,7 @@ pub enum Error {
     FromUtf8(#[from] std::string::FromUtf8Error),
 
     /// Error happening when there is a mismatch of the snappy CRC
-    #[error("Bad Snappy CRC32; expected {0:x} but got {1:x}")]
+    #[error("bad Snappy CRC32; expected {0:x} but got {1:x}")]
     SnappyCrcError(u32, u32),
 
     /// Errors coming from Snappy encoding and decoding

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -8,68 +8,71 @@ pub(crate) type AvroResult<T> = Result<T, Error>;
 #[derive(Error, Debug)]
 /// Error type returned from the library
 pub enum Error {
-    /// Represents all cases of `std::io::Error`
+    /// All cases of `std::io::Error`
     #[error(transparent)]
     IO(#[from] std::io::Error),
 
-    /// Describes errors happened while decoding Avro data (except for `std::io::Error`)
+    /// Error due to unrecognized coded
+    #[error("Unrecognized codec: {0:?}")]
+    Codec(String),
+
+    /// Errors happened while decoding Avro data (except for `std::io::Error`)
     #[error("Decoding error: {0}")]
     Decode(String),
 
-    /// Describes errors happened while parsing Avro schemas
+    /// Errors happened while parsing Avro schemas
     #[error("Failed to parse schema: {0}")]
     Parse(String),
 
-    /// Describes errors happened while performing schema resolution on Avro data.
+    /// Errors happened while performing schema resolution on Avro data
     #[error("Schema resolution error: {0}")]
     SchemaResolution(String),
 
-    /// Describes errors happened while validating Avro data.
+    /// Errors happened while validating Avro data
     #[error("Validation error: {0}")]
     Validation(String),
 
-    // TODO: figure out how to move the implementation of this error here
-    /// Describes errors that could be encountered while serializing data
+    /// Errors that could be encountered while serializing data
     #[error(transparent)]
     Ser(#[from] ser::Error),
 
-    // TODO: figure out how to move the implementation of this error here
-    /// Describes errors that could be encountered while serializing data
+    /// Errors that could be encountered while serializing data
     #[error(transparent)]
     De(#[from] de::Error),
 
     // TODO: merge with SerError somehow?
-    // /// Represents all cases of `serde::ser::Error`
+    // /// All cases of `serde::ser::Error`
     //#[error(transparent)]
     //SerdeSerError(#[from] serde::ser::Error),
-    /// Describes errors happened trying to allocate too many bytes
+    /// Error happened trying to allocate too many bytes
     #[error("Unable to allocate {desired} bytes (maximum allowed: {maximum})")]
     MemoryAllocation { desired: usize, maximum: usize },
 
-    /// Represents all cases of `uuid::Error`
+    /// All cases of `uuid::Error`
     #[error(transparent)]
     Uuid(#[from] uuid::Error),
 
-    /// Describe a specific error happening with decimal representation
+    /// Error happening with decimal representation
     #[error("Number of bytes requested for decimal sign extension {requested} is less than the number of bytes needed to decode {needed}")]
     SignExtend { requested: usize, needed: usize },
 
-    // TODO: Should this be wrapped by ParseSchemaError somehow?
-    /// Represents all cases of `std::num::TryFromIntError`
+    /// All cases of `std::num::TryFromIntError`
     #[error(transparent)]
     TryFromInt(#[from] std::num::TryFromIntError),
 
-    // TODO: Should this be wrapped by ParseSchemaError somehow?
-    /// Represents all cases of `serde_json::Error`
+    /// All cases of `serde_json::Error`
     #[error(transparent)]
     JSON(#[from] serde_json::Error),
 
-    // TODO: Should this be wrapped by SchemaResolutionError somehow?
-    /// Represents all cases of `std::string::FromUtf8Error`
+    /// All cases of `std::string::FromUtf8Error`
     #[error(transparent)]
     FromUtf8(#[from] std::string::FromUtf8Error),
 
-    /// Represents errors coming from Snappy encoding and decoding
+    /// Error happening when there is a mismatch of the snappy CRC
+    #[error("Bad Snappy CRC32; expected {0:x} but got {1:x}")]
+    SnappyCrcError(u32, u32),
+
+    /// Errors coming from Snappy encoding and decoding
     #[cfg(feature = "snappy")]
     #[error(transparent)]
     Snappy(#[from] snap::Error),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -63,8 +63,8 @@ pub enum Error {
     FromUtf8(#[from] std::string::FromUtf8Error),
 
     /// Error happening when there is a mismatch of the snappy CRC
-    #[error("bad Snappy CRC32; expected {0:x} but got {1:x}")]
-    SnappyCrcError(u32, u32),
+    #[error("bad Snappy CRC32; expected {expected:x} but got {found:x}")]
+    SnappyCrcError { expected: u32, found: u32 },
 
     /// Errors coming from Snappy encoding and decoding
     #[cfg(feature = "snappy")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,11 @@
 //! features = ["snappy"]
 //! ```
 //!
+//! # Upgrading to a newer minor version
+//!
+//! The library is still in beta, so there might be backward-incompatible changes between minor
+//! versions. If you have troubles upgrading, check the [version upgrade guide](migration_guide.md).
+//!
 //! # Defining a schema
 //!
 //! An Avro data cannot exist without an Avro schema. Schemas **must** be used while writing and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -689,13 +689,13 @@ pub mod schema_compatibility;
 pub mod types;
 
 pub use crate::codec::Codec;
-pub use crate::de::{from_value, Error as DeError};
+pub use crate::de::from_value;
 pub use crate::decimal::Decimal;
 pub use crate::duration::{Days, Duration, Millis, Months};
 pub use crate::errors::Error;
 pub use crate::reader::{from_avro_datum, Reader};
 pub use crate::schema::Schema;
-pub use crate::ser::{to_value, Error as SerError};
+pub use crate::ser::to_value;
 pub use crate::util::max_allocation_bytes;
 pub use crate::writer::{to_avro_datum, Writer};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,8 +409,7 @@
 //! quick reference of the library interface:
 //!
 //! ```
-//! use avro_rs::{Codec, Reader, Schema, Writer, from_value, types::Record};
-//! use failure::Error;
+//! use avro_rs::{Codec, Reader, Schema, Writer, from_value, types::Record, AvroError};
 //! use serde::{Deserialize, Serialize};
 //!
 //! #[derive(Debug, Deserialize, Serialize)]
@@ -419,7 +418,7 @@
 //!     b: String,
 //! }
 //!
-//! fn main() -> Result<(), Error> {
+//! fn main() -> Result<(), AvroError> {
 //!     let raw_schema = r#"
 //!         {
 //!             "type": "record",
@@ -475,12 +474,11 @@
 //! ```rust
 //! use avro_rs::{
 //!     types::Record, types::Value, Codec, Days, Decimal, Duration, Millis, Months, Reader, Schema,
-//!     Writer,
+//!     Writer, AvroError,
 //! };
 //! use num_bigint::ToBigInt;
-//! use failure::Error;
 //!
-//! fn main() -> Result<(), Error> {
+//! fn main() -> Result<(), AvroError> {
 //!     let raw_schema = r#"
 //!     {
 //!       "type": "record",
@@ -588,12 +586,11 @@
 //! An example of fingerprinting for the supported fingerprints:
 //!
 //! ```rust
-//! use avro_rs::Schema;
-//! use failure::Error;
+//! use avro_rs::{Schema, AvroError};
 //! use md5::Md5;
 //! use sha2::Sha256;
 //!
-//! fn main() -> Result<(), Error> {
+//! fn main() -> Result<(), AvroError> {
 //!     let raw_schema = r#"
 //!         {
 //!             "type": "record",
@@ -681,6 +678,7 @@ mod decimal;
 mod decode;
 mod duration;
 mod encode;
+mod errors;
 mod reader;
 mod ser;
 mod util;
@@ -694,12 +692,12 @@ pub use crate::codec::Codec;
 pub use crate::de::{from_value, Error as DeError};
 pub use crate::decimal::Decimal;
 pub use crate::duration::{Days, Duration, Millis, Months};
+pub use crate::errors::AvroError;
 pub use crate::reader::{from_avro_datum, Reader};
-pub use crate::schema::{ParseSchemaError, Schema};
+pub use crate::schema::Schema;
 pub use crate::ser::{to_value, Error as SerError};
-pub use crate::types::SchemaResolutionError;
-pub use crate::util::{max_allocation_bytes, DecodeError};
-pub use crate::writer::{to_avro_datum, ValidationError, Writer};
+pub use crate::util::max_allocation_bytes;
+pub use crate::writer::{to_avro_datum, Writer};
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,7 +409,7 @@
 //! quick reference of the library interface:
 //!
 //! ```
-//! use avro_rs::{Codec, Reader, Schema, Writer, from_value, types::Record, AvroError};
+//! use avro_rs::{Codec, Reader, Schema, Writer, from_value, types::Record, Error};
 //! use serde::{Deserialize, Serialize};
 //!
 //! #[derive(Debug, Deserialize, Serialize)]
@@ -418,7 +418,7 @@
 //!     b: String,
 //! }
 //!
-//! fn main() -> Result<(), AvroError> {
+//! fn main() -> Result<(), Error> {
 //!     let raw_schema = r#"
 //!         {
 //!             "type": "record",
@@ -474,11 +474,11 @@
 //! ```rust
 //! use avro_rs::{
 //!     types::Record, types::Value, Codec, Days, Decimal, Duration, Millis, Months, Reader, Schema,
-//!     Writer, AvroError,
+//!     Writer, Error,
 //! };
 //! use num_bigint::ToBigInt;
 //!
-//! fn main() -> Result<(), AvroError> {
+//! fn main() -> Result<(), Error> {
 //!     let raw_schema = r#"
 //!     {
 //!       "type": "record",
@@ -586,11 +586,11 @@
 //! An example of fingerprinting for the supported fingerprints:
 //!
 //! ```rust
-//! use avro_rs::{Schema, AvroError};
+//! use avro_rs::{Schema, Error};
 //! use md5::Md5;
 //! use sha2::Sha256;
 //!
-//! fn main() -> Result<(), AvroError> {
+//! fn main() -> Result<(), Error> {
 //!     let raw_schema = r#"
 //!         {
 //!             "type": "record",
@@ -692,7 +692,7 @@ pub use crate::codec::Codec;
 pub use crate::de::{from_value, Error as DeError};
 pub use crate::decimal::Decimal;
 pub use crate::duration::{Days, Duration, Millis, Months};
-pub use crate::errors::AvroError;
+pub use crate::errors::Error;
 pub use crate::reader::{from_avro_datum, Reader};
 pub use crate::schema::Schema;
 pub use crate::ser::{to_value, Error as SerError};

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2,14 +2,13 @@
 use std::io::{ErrorKind, Read};
 use std::str::{from_utf8, FromStr};
 
-use failure::Error;
 use serde_json::from_slice;
 
 use crate::decode::decode;
-use crate::schema::ParseSchemaError;
+use crate::errors::AvroError;
 use crate::schema::Schema;
 use crate::types::Value;
-use crate::util::{self, DecodeError};
+use crate::util;
 use crate::Codec;
 
 // Internal Block reader.
@@ -27,7 +26,7 @@ struct Block<R> {
 }
 
 impl<R: Read> Block<R> {
-    fn new(reader: R) -> Result<Block<R>, Error> {
+    fn new(reader: R) -> Result<Block<R>, AvroError> {
         let mut block = Block {
             reader,
             codec: Codec::Null,
@@ -44,14 +43,14 @@ impl<R: Read> Block<R> {
 
     /// Try to read the header and to set the writer `Schema`, the `Codec` and the marker based on
     /// its content.
-    fn read_header(&mut self) -> Result<(), Error> {
+    fn read_header(&mut self) -> Result<(), AvroError> {
         let meta_schema = Schema::Map(Box::new(Schema::Bytes));
 
         let mut buf = [0u8; 4];
         self.reader.read_exact(&mut buf)?;
 
         if buf != [b'O', b'b', b'j', 1u8] {
-            return Err(DecodeError::new("wrong magic in header").into());
+            return Err(AvroError::DecodeError("wrong magic in header".to_string()));
         }
 
         if let Value::Map(meta) = decode(&meta_schema, &mut self.reader)? {
@@ -69,7 +68,9 @@ impl<R: Read> Block<R> {
             if let Some(schema) = schema {
                 self.writer_schema = schema;
             } else {
-                return Err(ParseSchemaError::new("unable to parse schema").into());
+                return Err(AvroError::ParseSchemaError(
+                    "unable to parse schema".to_string(),
+                ));
             }
 
             if let Some(codec) = meta
@@ -86,7 +87,7 @@ impl<R: Read> Block<R> {
                 self.codec = codec;
             }
         } else {
-            return Err(DecodeError::new("no metadata in header").into());
+            return Err(AvroError::DecodeError("no metadata in header".to_string()));
         }
 
         let mut buf = [0u8; 16];
@@ -96,7 +97,7 @@ impl<R: Read> Block<R> {
         Ok(())
     }
 
-    fn fill_buf(&mut self, n: usize) -> Result<(), Error> {
+    fn fill_buf(&mut self, n: usize) -> Result<(), AvroError> {
         // The buffer needs to contain exactly `n` elements, otherwise codecs will potentially read
         // invalid bytes.
         //
@@ -116,7 +117,7 @@ impl<R: Read> Block<R> {
 
     /// Try to read a data block, also performing schema resolution for the objects contained in
     /// the block. The objects are stored in an internal buffer to the `Reader`.
-    fn read_block_next(&mut self) -> Result<(), Error> {
+    fn read_block_next(&mut self) -> Result<(), AvroError> {
         assert!(self.is_empty(), "Expected self to be empty!");
         match util::read_long(&mut self.reader) {
             Ok(block_len) => {
@@ -127,9 +128,9 @@ impl<R: Read> Block<R> {
                 self.reader.read_exact(&mut marker)?;
 
                 if marker != self.marker {
-                    return Err(
-                        DecodeError::new("block marker does not match header marker").into(),
-                    );
+                    return Err(AvroError::DecodeError(
+                        "block marker does not match header marker".to_string(),
+                    ));
                 }
 
                 // NOTE (JAB): This doesn't fit this Reader pattern very well.
@@ -143,13 +144,15 @@ impl<R: Read> Block<R> {
                 return Ok(());
             }
             Err(e) => {
-                if let ErrorKind::UnexpectedEof = e.downcast::<::std::io::Error>()?.kind() {
-                    // to not return any error in case we only finished to read cleanly from the stream
-                    return Ok(());
+                if let AvroError::IOError(ioe) = e {
+                    if let ErrorKind::UnexpectedEof = ioe.kind() {
+                        // to not return any error in case we only finished to read cleanly from the stream
+                        return Ok(());
+                    }
                 }
             }
         };
-        Err(DecodeError::new("unable to read block").into())
+        Err(AvroError::DecodeError("unable to read block".to_string()))
     }
 
     fn len(&self) -> usize {
@@ -160,7 +163,7 @@ impl<R: Read> Block<R> {
         self.len() == 0
     }
 
-    fn read_next(&mut self, read_schema: Option<&Schema>) -> Result<Option<Value>, Error> {
+    fn read_next(&mut self, read_schema: Option<&Schema>) -> Result<Option<Value>, AvroError> {
         if self.is_empty() {
             self.read_block_next()?;
             if self.is_empty() {
@@ -204,7 +207,7 @@ impl<'a, R: Read> Reader<'a, R> {
     /// No reader `Schema` will be set.
     ///
     /// **NOTE** The avro header is going to be read automatically upon creation of the `Reader`.
-    pub fn new(reader: R) -> Result<Reader<'a, R>, Error> {
+    pub fn new(reader: R) -> Result<Reader<'a, R>, AvroError> {
         let block = Block::new(reader)?;
         let reader = Reader {
             block,
@@ -219,7 +222,7 @@ impl<'a, R: Read> Reader<'a, R> {
     /// to read from.
     ///
     /// **NOTE** The avro header is going to be read automatically upon creation of the `Reader`.
-    pub fn with_schema(schema: &'a Schema, reader: R) -> Result<Reader<'a, R>, Error> {
+    pub fn with_schema(schema: &'a Schema, reader: R) -> Result<Reader<'a, R>, AvroError> {
         let block = Block::new(reader)?;
         let mut reader = Reader {
             block,
@@ -243,7 +246,7 @@ impl<'a, R: Read> Reader<'a, R> {
     }
 
     #[inline]
-    fn read_next(&mut self) -> Result<Option<Value>, Error> {
+    fn read_next(&mut self) -> Result<Option<Value>, AvroError> {
         let read_schema = if self.should_resolve_schema {
             self.reader_schema
         } else {
@@ -255,7 +258,7 @@ impl<'a, R: Read> Reader<'a, R> {
 }
 
 impl<'a, R: Read> Iterator for Reader<'a, R> {
-    type Item = Result<Value, Error>;
+    type Item = Result<Value, AvroError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // to prevent keep on reading after the first error occurs
@@ -284,7 +287,7 @@ pub fn from_avro_datum<R: Read>(
     writer_schema: &Schema,
     reader: &mut R,
     reader_schema: Option<&Schema>,
-) -> Result<Value, Error> {
+) -> Result<Value, AvroError> {
     let value = decode(writer_schema, reader)?;
     match reader_schema {
         Some(ref schema) => value.resolve(schema),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -5,29 +5,15 @@ use std::convert::TryInto;
 use std::fmt;
 
 use digest::Digest;
-use failure::{Error, Fail};
 use serde::{
     ser::{SerializeMap, SerializeSeq},
     Deserialize, Serialize, Serializer,
 };
 use serde_json::{Map, Value};
 
+use crate::errors::AvroError;
 use crate::types;
 use crate::util::MapHelper;
-
-/// Describes errors happened while parsing Avro schemas.
-#[derive(Fail, Debug)]
-#[fail(display = "Failed to parse schema: {}", _0)]
-pub struct ParseSchemaError(String);
-
-impl ParseSchemaError {
-    pub fn new<S>(msg: S) -> ParseSchemaError
-    where
-        S: Into<String>,
-    {
-        ParseSchemaError(msg.into())
-    }
-}
 
 /// Represents an Avro schema fingerprint
 /// More information about Avro schema fingerprints can be found in the
@@ -218,10 +204,10 @@ impl Name {
     }
 
     /// Parse a `serde_json::Value` into a `Name`.
-    fn parse(complex: &Map<String, Value>) -> Result<Self, Error> {
+    fn parse(complex: &Map<String, Value>) -> Result<Self, AvroError> {
         let name = complex
             .name()
-            .ok_or_else(|| ParseSchemaError::new("No `name` field"))?;
+            .ok_or_else(|| AvroError::ParseSchemaError("No `name` field".to_string()))?;
 
         let namespace = complex.string("namespace");
 
@@ -296,10 +282,10 @@ pub enum RecordFieldOrder {
 
 impl RecordField {
     /// Parse a `serde_json::Value` into a `RecordField`.
-    fn parse(field: &Map<String, Value>, position: usize) -> Result<Self, Error> {
+    fn parse(field: &Map<String, Value>, position: usize) -> Result<Self, AvroError> {
         let name = field
             .name()
-            .ok_or_else(|| ParseSchemaError::new("No `name` in record field"))?;
+            .ok_or_else(|| AvroError::ParseSchemaError("No `name` in record field".to_string()))?;
 
         // TODO: "type" = "<record name>"
         let schema = Schema::parse_complex(field)?;
@@ -339,17 +325,19 @@ pub struct UnionSchema {
 }
 
 impl UnionSchema {
-    pub(crate) fn new(schemas: Vec<Schema>) -> Result<Self, Error> {
+    pub(crate) fn new(schemas: Vec<Schema>) -> Result<Self, AvroError> {
         let mut vindex = HashMap::new();
         for (i, schema) in schemas.iter().enumerate() {
             if let Schema::Union(_) = schema {
-                return Err(
-                    ParseSchemaError::new("Unions may not directly contain a union").into(),
-                );
+                return Err(AvroError::ParseSchemaError(
+                    "Unions may not directly contain a union".to_string(),
+                ));
             }
             let kind = SchemaKind::from(schema);
             if vindex.insert(kind, i).is_some() {
-                return Err(ParseSchemaError::new("Unions cannot contain duplicate types").into());
+                return Err(AvroError::ParseSchemaError(
+                    "Unions cannot contain duplicate types".to_string(),
+                ));
             }
         }
         Ok(UnionSchema {
@@ -389,12 +377,14 @@ type DecimalMetadata = usize;
 pub(crate) type Precision = DecimalMetadata;
 pub(crate) type Scale = DecimalMetadata;
 
-fn parse_json_integer_for_decimal(value: &serde_json::Number) -> Result<DecimalMetadata, Error> {
+fn parse_json_integer_for_decimal(
+    value: &serde_json::Number,
+) -> Result<DecimalMetadata, AvroError> {
     if value.is_u64() {
         Ok(value
             .as_u64()
             .ok_or_else(|| {
-                ParseSchemaError::new(format!(
+                AvroError::ParseSchemaError(format!(
                     "JSON value {} claims to be u64 but cannot be converted",
                     value
                 ))
@@ -404,24 +394,23 @@ fn parse_json_integer_for_decimal(value: &serde_json::Number) -> Result<DecimalM
         Ok(value
             .as_i64()
             .ok_or_else(|| {
-                ParseSchemaError::new(format!(
+                AvroError::ParseSchemaError(format!(
                     "JSON value {} claims to be i64 but cannot be converted",
                     value
                 ))
             })?
             .try_into()?)
     } else {
-        Err(ParseSchemaError::new(format!(
+        Err(AvroError::ParseSchemaError(format!(
             "Invalid JSON value for decimal precision/scale integer: {}",
             value
-        ))
-        .into())
+        )))
     }
 }
 
 impl Schema {
     /// Create a `Schema` from a string representing a JSON Avro schema.
-    pub fn parse_str(input: &str) -> Result<Self, Error> {
+    pub fn parse_str(input: &str) -> Result<Self, AvroError> {
         // TODO: (#82) this should be a ParseSchemaError wrapping the JSON error
         let value = serde_json::from_str(input)?;
         Self::parse(&value)
@@ -429,12 +418,14 @@ impl Schema {
 
     /// Create a `Schema` from a `serde_json::Value` representing a JSON Avro
     /// schema.
-    pub fn parse(value: &Value) -> Result<Self, Error> {
+    pub fn parse(value: &Value) -> Result<Self, AvroError> {
         match *value {
             Value::String(ref t) => Schema::parse_primitive(t.as_str()),
             Value::Object(ref data) => Schema::parse_complex(data),
             Value::Array(ref data) => Schema::parse_union(data),
-            _ => Err(ParseSchemaError::new("Must be a JSON string, object or array").into()),
+            _ => Err(AvroError::ParseSchemaError(
+                "Must be a JSON string, object or array".to_string(),
+            )),
         }
     }
 
@@ -463,7 +454,7 @@ impl Schema {
 
     /// Parse a `serde_json::Value` representing a primitive Avro type into a
     /// `Schema`.
-    fn parse_primitive(primitive: &str) -> Result<Self, Error> {
+    fn parse_primitive(primitive: &str) -> Result<Self, AvroError> {
         match primitive {
             "null" => Ok(Schema::Null),
             "boolean" => Ok(Schema::Boolean),
@@ -473,27 +464,30 @@ impl Schema {
             "float" => Ok(Schema::Float),
             "bytes" => Ok(Schema::Bytes),
             "string" => Ok(Schema::String),
-            other => Err(ParseSchemaError::new(format!("Unknown type: {}", other)).into()),
+            other => Err(AvroError::ParseSchemaError(format!(
+                "Unknown type: {}",
+                other
+            ))),
         }
     }
 
     fn parse_precision_and_scale(
         complex: &Map<String, Value>,
-    ) -> Result<(Precision, Scale), Error> {
+    ) -> Result<(Precision, Scale), AvroError> {
         fn get_decimal_integer(
             complex: &Map<String, Value>,
             key: &str,
-        ) -> Result<DecimalMetadata, Error> {
+        ) -> Result<DecimalMetadata, AvroError> {
             match complex.get(key) {
                 Some(&Value::Number(ref value)) => parse_json_integer_for_decimal(value),
-                None => {
-                    Err(ParseSchemaError::new(format!("{} missing for decimal type", key)).into())
-                }
-                precision => Err(ParseSchemaError::new(format!(
+                None => Err(AvroError::ParseSchemaError(format!(
+                    "{} missing for decimal type",
+                    key
+                ))),
+                precision => Err(AvroError::ParseSchemaError(format!(
                     "invalid JSON for {}: {:?}",
                     key, precision,
-                ))
-                .into()),
+                ))),
             }
         }
         let precision = get_decimal_integer(complex, "precision")?;
@@ -506,11 +500,11 @@ impl Schema {
     ///
     /// Avro supports "recursive" definition of types.
     /// e.g: {"type": {"type": "string"}}
-    fn parse_complex(complex: &Map<String, Value>) -> Result<Self, Error> {
+    fn parse_complex(complex: &Map<String, Value>) -> Result<Self, AvroError> {
         fn logical_verify_type(
             complex: &Map<String, Value>,
             kinds: &[SchemaKind],
-        ) -> Result<Schema, Error> {
+        ) -> Result<Schema, AvroError> {
             match complex.get("type") {
                 Some(value) => {
                     let ty = Schema::parse(value)?;
@@ -520,16 +514,15 @@ impl Schema {
                     {
                         Ok(ty)
                     } else {
-                        Err(ParseSchemaError::new(format!(
+                        Err(AvroError::ParseSchemaError(format!(
                             "Unexpected `type` ({}) variant for `logicalType`",
                             value
-                        ))
-                        .into())
+                        )))
                     }
                 }
-                None => {
-                    Err(ParseSchemaError::new("No `type` field found for `logicalType`").into())
-                }
+                None => Err(AvroError::ParseSchemaError(
+                    "No `type` field found for `logicalType`".to_string(),
+                )),
             }
         }
         match complex.get("logicalType") {
@@ -583,7 +576,11 @@ impl Schema {
             // The spec says to ignore invalid logical types and just continue through to the
             // underlying type - It is unclear whether that applies to this case or not, where the
             // `logicalType` is not a string.
-            Some(_) => return Err(ParseSchemaError::new("logicalType must be a string").into()),
+            Some(_) => {
+                return Err(AvroError::ParseSchemaError(
+                    "logicalType must be a string".to_string(),
+                ))
+            }
             _ => {}
         }
         match complex.get("type") {
@@ -597,16 +594,19 @@ impl Schema {
             },
             Some(&Value::Object(ref data)) => Schema::parse_complex(data),
             Some(&Value::Array(ref variants)) => Schema::parse_union(variants),
-            Some(unknown) => {
-                Err(ParseSchemaError::new(format!("Unknown complex type: {0:?}", unknown)).into())
-            }
-            None => Err(ParseSchemaError::new("No `type` in complex type").into()),
+            Some(unknown) => Err(AvroError::ParseSchemaError(format!(
+                "Unknown complex type: {0:?}",
+                unknown
+            ))),
+            None => Err(AvroError::ParseSchemaError(
+                "No `type` in complex type".to_string(),
+            )),
         }
     }
 
     /// Parse a `serde_json::Value` representing a Avro record type into a
     /// `Schema`.
-    fn parse_record(complex: &Map<String, Value>) -> Result<Self, Error> {
+    fn parse_record(complex: &Map<String, Value>) -> Result<Self, AvroError> {
         let name = Name::parse(complex)?;
 
         let mut lookup = HashMap::new();
@@ -614,7 +614,7 @@ impl Schema {
         let fields: Vec<RecordField> = complex
             .get("fields")
             .and_then(|fields| fields.as_array())
-            .ok_or_else(|| ParseSchemaError::new("No `fields` in record").into())
+            .ok_or_else(|| AvroError::ParseSchemaError("No `fields` in record".to_string()))
             .and_then(|fields| {
                 fields
                     .iter()
@@ -638,19 +638,21 @@ impl Schema {
 
     /// Parse a `serde_json::Value` representing a Avro enum type into a
     /// `Schema`.
-    fn parse_enum(complex: &Map<String, Value>) -> Result<Self, Error> {
+    fn parse_enum(complex: &Map<String, Value>) -> Result<Self, AvroError> {
         let name = Name::parse(complex)?;
 
         let symbols = complex
             .get("symbols")
             .and_then(|v| v.as_array())
-            .ok_or_else(|| ParseSchemaError::new("No `symbols` field in enum"))
+            .ok_or_else(|| AvroError::ParseSchemaError("No `symbols` field in enum".to_string()))
             .and_then(|symbols| {
                 symbols
                     .iter()
                     .map(|symbol| symbol.as_str().map(|s| s.to_string()))
                     .collect::<Option<_>>()
-                    .ok_or_else(|| ParseSchemaError::new("Unable to parse `symbols` in enum"))
+                    .ok_or_else(|| {
+                        AvroError::ParseSchemaError("Unable to parse `symbols` in enum".to_string())
+                    })
             })?;
 
         Ok(Schema::Enum {
@@ -662,27 +664,27 @@ impl Schema {
 
     /// Parse a `serde_json::Value` representing a Avro array type into a
     /// `Schema`.
-    fn parse_array(complex: &Map<String, Value>) -> Result<Self, Error> {
+    fn parse_array(complex: &Map<String, Value>) -> Result<Self, AvroError> {
         complex
             .get("items")
-            .ok_or_else(|| ParseSchemaError::new("No `items` in array").into())
+            .ok_or_else(|| AvroError::ParseSchemaError("No `items` in array".to_string()))
             .and_then(|items| Schema::parse(items))
             .map(|schema| Schema::Array(Box::new(schema)))
     }
 
     /// Parse a `serde_json::Value` representing a Avro map type into a
     /// `Schema`.
-    fn parse_map(complex: &Map<String, Value>) -> Result<Self, Error> {
+    fn parse_map(complex: &Map<String, Value>) -> Result<Self, AvroError> {
         complex
             .get("values")
-            .ok_or_else(|| ParseSchemaError::new("No `values` in map").into())
+            .ok_or_else(|| AvroError::ParseSchemaError("No `values` in map".to_string()))
             .and_then(|items| Schema::parse(items))
             .map(|schema| Schema::Map(Box::new(schema)))
     }
 
     /// Parse a `serde_json::Value` representing a Avro union type into a
     /// `Schema`.
-    fn parse_union(items: &[Value]) -> Result<Self, Error> {
+    fn parse_union(items: &[Value]) -> Result<Self, AvroError> {
         items
             .iter()
             .map(Schema::parse)
@@ -692,13 +694,13 @@ impl Schema {
 
     /// Parse a `serde_json::Value` representing a Avro fixed type into a
     /// `Schema`.
-    fn parse_fixed(complex: &Map<String, Value>) -> Result<Self, Error> {
+    fn parse_fixed(complex: &Map<String, Value>) -> Result<Self, AvroError> {
         let name = Name::parse(complex)?;
 
         let size = complex
             .get("size")
             .and_then(|v| v.as_i64())
-            .ok_or_else(|| ParseSchemaError::new("No `size` in fixed"))?;
+            .ok_or_else(|| AvroError::ParseSchemaError("No `size` in fixed".to_string()))?;
 
         Ok(Schema::Fixed {
             name,

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,27 +5,13 @@ use std::hash::BuildHasher;
 use std::str::FromStr;
 use std::u8;
 
-use failure::{Error, Fail};
 use serde_json::Value as JsonValue;
 use uuid::Uuid;
 
 use crate::decimal::Decimal;
 use crate::duration::Duration;
+use crate::errors::AvroError;
 use crate::schema::{Precision, RecordField, Scale, Schema, SchemaKind, UnionSchema};
-
-/// Describes errors happened while performing schema resolution on Avro data.
-#[derive(Fail, Debug)]
-#[fail(display = "Schema resoulution error: {}", _0)]
-pub struct SchemaResolutionError(pub String);
-
-impl SchemaResolutionError {
-    pub fn new<S>(msg: S) -> SchemaResolutionError
-    where
-        S: Into<String>,
-    {
-        SchemaResolutionError(msg.into())
-    }
-}
 
 /// Compute the maximum decimal value precision of a byte array of length `len` could hold.
 fn max_prec_for_len(len: usize) -> Result<usize, std::num::TryFromIntError> {
@@ -333,7 +319,7 @@ impl Value {
     /// See [Schema Resolution](https://avro.apache.org/docs/current/spec.html#Schema+Resolution)
     /// in the Avro specification for the full set of rules of schema
     /// resolution.
-    pub fn resolve(mut self, schema: &Schema) -> Result<Self, Error> {
+    pub fn resolve(mut self, schema: &Schema) -> Result<Self, AvroError> {
         // Check if this schema is a union, and if the reader schema is not.
         if SchemaKind::from(&self) == SchemaKind::Union
             && SchemaKind::from(schema) != SchemaKind::Union
@@ -375,35 +361,36 @@ impl Value {
         }
     }
 
-    fn resolve_uuid(self) -> Result<Self, Error> {
+    fn resolve_uuid(self) -> Result<Self, AvroError> {
         match self {
             uuid @ Value::Uuid(_) => Ok(uuid),
             Value::String(ref string) => Ok(Value::Uuid(Uuid::from_str(string)?)),
-            other => {
-                Err(SchemaResolutionError::new(format!("UUID expected, got {:?}", other)).into())
-            }
+            other => Err(AvroError::SchemaResolutionError(format!(
+                "UUID expected, got {:?}",
+                other
+            ))),
         }
     }
 
-    fn resolve_duration(self) -> Result<Self, Error> {
+    fn resolve_duration(self) -> Result<Self, AvroError> {
         match self {
             duration @ Value::Duration { .. } => Ok(duration),
             Value::Fixed(size, bytes) => {
                 if size != 12 {
-                    return Err(SchemaResolutionError::new(format!(
+                    return Err(AvroError::SchemaResolutionError(format!(
                         "Fixed bytes of size 12 expected, got Fixed of size {}",
                         size
-                    ))
-                    .into());
+                    )));
                 }
                 Ok(Value::Duration(Duration::from([
                     bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
                     bytes[8], bytes[9], bytes[10], bytes[11],
                 ])))
             }
-            other => Err(
-                SchemaResolutionError::new(format!("Duration expected, got {:?}", other)).into(),
-            ),
+            other => Err(AvroError::SchemaResolutionError(format!(
+                "Duration expected, got {:?}",
+                other
+            ))),
         }
     }
 
@@ -412,42 +399,38 @@ impl Value {
         precision: Precision,
         scale: Scale,
         inner: &Schema,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, AvroError> {
         if scale > precision {
-            return Err(SchemaResolutionError::new(format!(
+            return Err(AvroError::SchemaResolutionError(format!(
                 "Scale {} is greater than precision {}",
                 scale, precision
-            ))
-            .into());
+            )));
         }
         match inner {
             &Schema::Fixed { size, .. } => {
                 if max_prec_for_len(size)? < precision {
-                    return Err(SchemaResolutionError::new(format!(
+                    return Err(AvroError::SchemaResolutionError(format!(
                         "Fixed size {} is not large enough to hold decimal values of precision {}",
                         size, precision,
-                    ))
-                    .into());
+                    )));
                 }
             }
             Schema::Bytes => (),
             _ => {
-                return Err(SchemaResolutionError::new(format!(
+                return Err(AvroError::SchemaResolutionError(format!(
                     "Underlying decimal type must be fixed or bytes, got {:?}",
                     inner
-                ))
-                .into())
+                )))
             }
         };
         match self {
             Value::Decimal(num) => {
                 let num_bytes = num.len();
                 if max_prec_for_len(num_bytes)? > precision {
-                    Err(SchemaResolutionError::new(format!(
+                    Err(AvroError::SchemaResolutionError(format!(
                         "Precision {} too small to hold decimal values with {} bytes",
                         precision, num_bytes,
-                    ))
-                    .into())
+                    )))
                 } else {
                     Ok(Value::Decimal(num))
                 }
@@ -455,142 +438,145 @@ impl Value {
             }
             Value::Fixed(_, bytes) | Value::Bytes(bytes) => {
                 if max_prec_for_len(bytes.len())? > precision {
-                    Err(SchemaResolutionError::new(format!(
+                    Err(AvroError::SchemaResolutionError(format!(
                         "Precision {} too small to hold decimal values with {} bytes",
                         precision,
                         bytes.len(),
-                    ))
-                    .into())
+                    )))
                 } else {
                     // precision and scale match, can we assume the underlying type can hold the data?
                     Ok(Value::Decimal(Decimal::from(bytes)))
                 }
             }
-            other => {
-                Err(SchemaResolutionError::new(format!("Decimal expected, got {:?}", other)).into())
-            }
+            other => Err(AvroError::SchemaResolutionError(format!(
+                "Decimal expected, got {:?}",
+                other
+            ))),
         }
     }
 
-    fn resolve_date(self) -> Result<Self, Error> {
+    fn resolve_date(self) -> Result<Self, AvroError> {
         match self {
             Value::Date(d) | Value::Int(d) => Ok(Value::Date(d)),
-            other => {
-                Err(SchemaResolutionError::new(format!("Date expected, got {:?}", other)).into())
-            }
+            other => Err(AvroError::SchemaResolutionError(format!(
+                "Date expected, got {:?}",
+                other
+            ))),
         }
     }
 
-    fn resolve_time_millis(self) -> Result<Self, Error> {
+    fn resolve_time_millis(self) -> Result<Self, AvroError> {
         match self {
             Value::TimeMillis(t) | Value::Int(t) => Ok(Value::TimeMillis(t)),
-            other => Err(SchemaResolutionError::new(format!(
+            other => Err(AvroError::SchemaResolutionError(format!(
                 "TimeMillis expected, got {:?}",
                 other
-            ))
-            .into()),
+            ))),
         }
     }
 
-    fn resolve_time_micros(self) -> Result<Self, Error> {
+    fn resolve_time_micros(self) -> Result<Self, AvroError> {
         match self {
             Value::TimeMicros(t) | Value::Long(t) => Ok(Value::TimeMicros(t)),
             Value::Int(t) => Ok(Value::TimeMicros(i64::from(t))),
-            other => Err(SchemaResolutionError::new(format!(
+            other => Err(AvroError::SchemaResolutionError(format!(
                 "TimeMicros expected, got {:?}",
                 other
-            ))
-            .into()),
+            ))),
         }
     }
 
-    fn resolve_timestamp_millis(self) -> Result<Self, Error> {
+    fn resolve_timestamp_millis(self) -> Result<Self, AvroError> {
         match self {
             Value::TimestampMillis(ts) | Value::Long(ts) => Ok(Value::TimestampMillis(ts)),
             Value::Int(ts) => Ok(Value::TimestampMillis(i64::from(ts))),
-            other => Err(SchemaResolutionError::new(format!(
+            other => Err(AvroError::SchemaResolutionError(format!(
                 "TimestampMillis expected, got {:?}",
                 other
-            ))
-            .into()),
+            ))),
         }
     }
 
-    fn resolve_timestamp_micros(self) -> Result<Self, Error> {
+    fn resolve_timestamp_micros(self) -> Result<Self, AvroError> {
         match self {
             Value::TimestampMicros(ts) | Value::Long(ts) => Ok(Value::TimestampMicros(ts)),
             Value::Int(ts) => Ok(Value::TimestampMicros(i64::from(ts))),
-            other => Err(SchemaResolutionError::new(format!(
+            other => Err(AvroError::SchemaResolutionError(format!(
                 "TimestampMicros expected, got {:?}",
                 other
-            ))
-            .into()),
+            ))),
         }
     }
 
-    fn resolve_null(self) -> Result<Self, Error> {
+    fn resolve_null(self) -> Result<Self, AvroError> {
         match self {
             Value::Null => Ok(Value::Null),
-            other => {
-                Err(SchemaResolutionError::new(format!("Null expected, got {:?}", other)).into())
-            }
+            other => Err(AvroError::SchemaResolutionError(format!(
+                "Null expected, got {:?}",
+                other
+            ))),
         }
     }
 
-    fn resolve_boolean(self) -> Result<Self, Error> {
+    fn resolve_boolean(self) -> Result<Self, AvroError> {
         match self {
             Value::Boolean(b) => Ok(Value::Boolean(b)),
-            other => {
-                Err(SchemaResolutionError::new(format!("Boolean expected, got {:?}", other)).into())
-            }
+            other => Err(AvroError::SchemaResolutionError(format!(
+                "Boolean expected, got {:?}",
+                other
+            ))),
         }
     }
 
-    fn resolve_int(self) -> Result<Self, Error> {
+    fn resolve_int(self) -> Result<Self, AvroError> {
         match self {
             Value::Int(n) => Ok(Value::Int(n)),
             Value::Long(n) => Ok(Value::Int(n as i32)),
-            other => {
-                Err(SchemaResolutionError::new(format!("Int expected, got {:?}", other)).into())
-            }
+            other => Err(AvroError::SchemaResolutionError(format!(
+                "Int expected, got {:?}",
+                other
+            ))),
         }
     }
 
-    fn resolve_long(self) -> Result<Self, Error> {
+    fn resolve_long(self) -> Result<Self, AvroError> {
         match self {
             Value::Int(n) => Ok(Value::Long(i64::from(n))),
             Value::Long(n) => Ok(Value::Long(n)),
-            other => {
-                Err(SchemaResolutionError::new(format!("Long expected, got {:?}", other)).into())
-            }
+            other => Err(AvroError::SchemaResolutionError(format!(
+                "Long expected, got {:?}",
+                other
+            ))),
         }
     }
 
-    fn resolve_float(self) -> Result<Self, Error> {
+    fn resolve_float(self) -> Result<Self, AvroError> {
         match self {
             Value::Int(n) => Ok(Value::Float(n as f32)),
             Value::Long(n) => Ok(Value::Float(n as f32)),
             Value::Float(x) => Ok(Value::Float(x)),
             Value::Double(x) => Ok(Value::Float(x as f32)),
-            other => {
-                Err(SchemaResolutionError::new(format!("Float expected, got {:?}", other)).into())
-            }
+            other => Err(AvroError::SchemaResolutionError(format!(
+                "Float expected, got {:?}",
+                other
+            ))),
         }
     }
 
-    fn resolve_double(self) -> Result<Self, Error> {
+    fn resolve_double(self) -> Result<Self, AvroError> {
         match self {
             Value::Int(n) => Ok(Value::Double(f64::from(n))),
             Value::Long(n) => Ok(Value::Double(n as f64)),
             Value::Float(x) => Ok(Value::Double(f64::from(x))),
             Value::Double(x) => Ok(Value::Double(x)),
-            other => {
-                Err(SchemaResolutionError::new(format!("Double expected, got {:?}", other)).into())
-            }
+            other => Err(AvroError::SchemaResolutionError(format!(
+                "Double expected, got {:?}",
+                other
+            ))),
         }
     }
 
-    fn resolve_bytes(self) -> Result<Self, Error> {
+    fn resolve_bytes(self) -> Result<Self, AvroError> {
         match self {
             Value::Bytes(bytes) => Ok(Value::Bytes(bytes)),
             Value::String(s) => Ok(Value::Bytes(s.into_bytes())),
@@ -600,51 +586,52 @@ impl Value {
                     .map(Value::try_u8)
                     .collect::<Result<Vec<_>, _>>()?,
             )),
-            other => {
-                Err(SchemaResolutionError::new(format!("Bytes expected, got {:?}", other)).into())
-            }
+            other => Err(AvroError::SchemaResolutionError(format!(
+                "Bytes expected, got {:?}",
+                other
+            ))),
         }
     }
 
-    fn resolve_string(self) -> Result<Self, Error> {
+    fn resolve_string(self) -> Result<Self, AvroError> {
         match self {
             Value::String(s) => Ok(Value::String(s)),
             Value::Bytes(bytes) => Ok(Value::String(String::from_utf8(bytes)?)),
-            other => {
-                Err(SchemaResolutionError::new(format!("String expected, got {:?}", other)).into())
-            }
+            other => Err(AvroError::SchemaResolutionError(format!(
+                "String expected, got {:?}",
+                other
+            ))),
         }
     }
 
-    fn resolve_fixed(self, size: usize) -> Result<Self, Error> {
+    fn resolve_fixed(self, size: usize) -> Result<Self, AvroError> {
         match self {
             Value::Fixed(n, bytes) => {
                 if n == size {
                     Ok(Value::Fixed(n, bytes))
                 } else {
-                    Err(SchemaResolutionError::new(format!(
+                    Err(AvroError::SchemaResolutionError(format!(
                         "Fixed size mismatch, {} expected, got {}",
                         size, n
-                    ))
-                    .into())
+                    )))
                 }
             }
-            other => {
-                Err(SchemaResolutionError::new(format!("String expected, got {:?}", other)).into())
-            }
+            other => Err(AvroError::SchemaResolutionError(format!(
+                "String expected, got {:?}",
+                other
+            ))),
         }
     }
 
-    fn resolve_enum(self, symbols: &[String]) -> Result<Self, Error> {
+    fn resolve_enum(self, symbols: &[String]) -> Result<Self, AvroError> {
         let validate_symbol = |symbol: String, symbols: &[String]| {
             if let Some(index) = symbols.iter().position(|ref item| item == &&symbol) {
                 Ok(Value::Enum(index as i32, symbol))
             } else {
-                Err(SchemaResolutionError::new(format!(
+                Err(AvroError::SchemaResolutionError(format!(
                     "Enum default {} is not among allowed symbols {:?}",
                     symbol, symbols,
-                ))
-                .into())
+                )))
             }
         };
 
@@ -653,24 +640,22 @@ impl Value {
                 if i >= 0 && i < symbols.len() as i32 {
                     validate_symbol(s, symbols)
                 } else {
-                    Err(SchemaResolutionError::new(format!(
+                    Err(AvroError::SchemaResolutionError(format!(
                         "Enum value {} is out of bound {}",
                         i,
                         symbols.len() as i32
-                    ))
-                    .into())
+                    )))
                 }
             }
             Value::String(s) => validate_symbol(s, symbols),
-            other => Err(SchemaResolutionError::new(format!(
+            other => Err(AvroError::SchemaResolutionError(format!(
                 "Enum({:?}) expected, got {:?}",
                 symbols, other
-            ))
-            .into()),
+            ))),
         }
     }
 
-    fn resolve_union(self, schema: &UnionSchema) -> Result<Self, Error> {
+    fn resolve_union(self, schema: &UnionSchema) -> Result<Self, AvroError> {
         let v = match self {
             // Both are unions case.
             Value::Union(v) => *v,
@@ -678,13 +663,13 @@ impl Value {
             v => v,
         };
         // Find the first match in the reader schema.
-        let (_, inner) = schema
-            .find_schema(&v)
-            .ok_or_else(|| SchemaResolutionError::new("Could not find matching type in union"))?;
+        let (_, inner) = schema.find_schema(&v).ok_or_else(|| {
+            AvroError::SchemaResolutionError("Could not find matching type in union".to_string())
+        })?;
         Ok(Value::Union(Box::new(v.resolve(inner)?)))
     }
 
-    fn resolve_array(self, schema: &Schema) -> Result<Self, Error> {
+    fn resolve_array(self, schema: &Schema) -> Result<Self, AvroError> {
         match self {
             Value::Array(items) => Ok(Value::Array(
                 items
@@ -692,15 +677,14 @@ impl Value {
                     .map(|item| item.resolve(schema))
                     .collect::<Result<_, _>>()?,
             )),
-            other => Err(SchemaResolutionError::new(format!(
+            other => Err(AvroError::SchemaResolutionError(format!(
                 "Array({:?}) expected, got {:?}",
                 schema, other
-            ))
-            .into()),
+            ))),
         }
     }
 
-    fn resolve_map(self, schema: &Schema) -> Result<Self, Error> {
+    fn resolve_map(self, schema: &Schema) -> Result<Self, AvroError> {
         match self {
             Value::Map(items) => Ok(Value::Map(
                 items
@@ -708,22 +692,21 @@ impl Value {
                     .map(|(key, value)| value.resolve(schema).map(|value| (key, value)))
                     .collect::<Result<_, _>>()?,
             )),
-            other => Err(SchemaResolutionError::new(format!(
+            other => Err(AvroError::SchemaResolutionError(format!(
                 "Map({:?}) expected, got {:?}",
                 schema, other
-            ))
-            .into()),
+            ))),
         }
     }
 
-    fn resolve_record(self, fields: &[RecordField]) -> Result<Self, Error> {
+    fn resolve_record(self, fields: &[RecordField]) -> Result<Self, AvroError> {
         let mut items = match self {
             Value::Map(items) => Ok(items),
             Value::Record(fields) => Ok(fields.into_iter().collect::<HashMap<_, _>>()),
-            other => Err(Error::from(SchemaResolutionError::new(format!(
+            other => Err(AvroError::SchemaResolutionError(format!(
                 "Record({:?}) expected, got {:?}",
                 fields, other
-            )))),
+            ))),
         }?;
 
         let new_fields = fields
@@ -750,11 +733,10 @@ impl Value {
                             _ => Value::from(value.clone()),
                         },
                         None => {
-                            return Err(SchemaResolutionError::new(format!(
+                            return Err(AvroError::SchemaResolutionError(format!(
                                 "missing field {} in record",
                                 field.name
-                            ))
-                            .into());
+                            )));
                         }
                     },
                 };
@@ -767,7 +749,7 @@ impl Value {
         Ok(Value::Record(new_fields))
     }
 
-    fn try_u8(self) -> Result<u8, Error> {
+    fn try_u8(self) -> Result<u8, AvroError> {
         let int = self.resolve(&Schema::Int)?;
         if let Value::Int(n) = int {
             if n >= 0 && n <= i32::from(u8::MAX) {
@@ -775,7 +757,10 @@ impl Value {
             }
         }
 
-        Err(SchemaResolutionError::new(format!("Unable to convert to u8, got {:?}", int)).into())
+        Err(AvroError::SchemaResolutionError(format!(
+            "Unable to convert to u8, got {:?}",
+            int
+        )))
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,8 +2,9 @@ use std::i64;
 use std::io::Read;
 use std::sync::Once;
 
-use failure::{Error, Fail};
 use serde_json::{Map, Value};
+
+use crate::errors::AvroError;
 
 /// Maximum number of bytes that can be allocated when decoding
 /// Avro-encoded values. This is a protection against ill-formed
@@ -11,34 +12,6 @@ use serde_json::{Map, Value};
 /// See max_allocation_bytes to change this limit.
 pub static mut MAX_ALLOCATION_BYTES: usize = 512 * 1024 * 1024;
 static MAX_ALLOCATION_BYTES_ONCE: Once = Once::new();
-
-/// Describes errors happened trying to allocate too many bytes
-#[derive(Fail, Debug)]
-#[fail(display = "Allocation error: {}", _0)]
-pub struct AllocationError(String);
-
-impl AllocationError {
-    pub fn new<S>(msg: S) -> AllocationError
-    where
-        S: Into<String>,
-    {
-        AllocationError(msg.into())
-    }
-}
-
-/// Describes errors happened while decoding Avro data.
-#[derive(Fail, Debug)]
-#[fail(display = "Decoding error: {}", _0)]
-pub struct DecodeError(String);
-
-impl DecodeError {
-    pub fn new<S>(msg: S) -> DecodeError
-    where
-        S: Into<String>,
-    {
-        DecodeError(msg.into())
-    }
-}
 
 pub trait MapHelper {
     fn string(&self, key: &str) -> Option<String>;
@@ -60,7 +33,7 @@ impl MapHelper for Map<String, Value> {
     }
 }
 
-pub fn read_long<R: Read>(reader: &mut R) -> Result<i64, Error> {
+pub fn read_long<R: Read>(reader: &mut R) -> Result<i64, AvroError> {
     zag_i64(reader)
 }
 
@@ -72,16 +45,16 @@ pub fn zig_i64(n: i64, buffer: &mut Vec<u8>) {
     encode_variable(((n << 1) ^ (n >> 63)) as u64, buffer)
 }
 
-pub fn zag_i32<R: Read>(reader: &mut R) -> Result<i32, Error> {
+pub fn zag_i32<R: Read>(reader: &mut R) -> Result<i32, AvroError> {
     let i = zag_i64(reader)?;
     if i < i64::from(i32::min_value()) || i > i64::from(i32::max_value()) {
-        Err(DecodeError::new("int out of range").into())
+        Err(AvroError::DecodeError("int out of range".to_string()))
     } else {
         Ok(i as i32)
     }
 }
 
-pub fn zag_i64<R: Read>(reader: &mut R) -> Result<i64, Error> {
+pub fn zag_i64<R: Read>(reader: &mut R) -> Result<i64, AvroError> {
     let z = decode_variable(reader)?;
     Ok(if z & 0x1 == 0 {
         (z >> 1) as i64
@@ -102,7 +75,7 @@ fn encode_variable(mut z: u64, buffer: &mut Vec<u8>) {
     }
 }
 
-fn decode_variable<R: Read>(reader: &mut R) -> Result<u64, Error> {
+fn decode_variable<R: Read>(reader: &mut R) -> Result<u64, AvroError> {
     let mut i = 0u64;
     let mut buf = [0u8; 1];
 
@@ -110,7 +83,9 @@ fn decode_variable<R: Read>(reader: &mut R) -> Result<u64, Error> {
     loop {
         if j > 9 {
             // if j * 7 > 64
-            return Err(DecodeError::new("Overflow when decoding integer value").into());
+            return Err(AvroError::DecodeError(
+                "Overflow when decoding integer value".to_string(),
+            ));
         }
         reader.read_exact(&mut buf[..])?;
         i |= (u64::from(buf[0] & 0x7F)) << (j * 7);
@@ -140,17 +115,16 @@ pub fn max_allocation_bytes(num_bytes: usize) -> usize {
     }
 }
 
-pub fn safe_len(len: usize) -> Result<usize, Error> {
+pub fn safe_len(len: usize) -> Result<usize, AvroError> {
     let max_bytes = max_allocation_bytes(512 * 1024 * 1024);
 
     if len <= max_bytes {
         Ok(len)
     } else {
-        Err(AllocationError::new(format!(
-            "Unable to allocate {} bytes (Maximum allowed: {})",
-            len, max_bytes
-        ))
-        .into())
+        Err(AvroError::MemoryAllocationError {
+            desired: len,
+            maximum: max_bytes,
+        })
     }
 }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -6,7 +6,7 @@ use rand::random;
 use serde::Serialize;
 
 use crate::encode::{encode, encode_ref, encode_to_vec};
-use crate::errors::AvroError;
+use crate::errors::{AvroResult, Error};
 use crate::schema::Schema;
 use crate::ser::Serializer;
 use crate::types::Value;
@@ -67,7 +67,7 @@ impl<'a, W: Write> Writer<'a, W> {
     /// **NOTE** This function is not guaranteed to perform any actual write, since it relies on
     /// internal buffering for performance reasons. If you want to be sure the value has been
     /// written, then call [`flush`](struct.Writer.html#method.flush).
-    pub fn append<T: Into<Value>>(&mut self, value: T) -> Result<usize, AvroError> {
+    pub fn append<T: Into<Value>>(&mut self, value: T) -> AvroResult<usize> {
         let n = if !self.has_header {
             let header = self.header()?;
             let n = self.append_bytes(header.as_ref())?;
@@ -96,7 +96,7 @@ impl<'a, W: Write> Writer<'a, W> {
     /// **NOTE** This function is not guaranteed to perform any actual write, since it relies on
     /// internal buffering for performance reasons. If you want to be sure the value has been
     /// written, then call [`flush`](struct.Writer.html#method.flush).
-    pub fn append_value_ref(&mut self, value: &Value) -> Result<usize, AvroError> {
+    pub fn append_value_ref(&mut self, value: &Value) -> AvroResult<usize> {
         let n = if !self.has_header {
             let header = self.header()?;
             let n = self.append_bytes(header.as_ref())?;
@@ -126,7 +126,7 @@ impl<'a, W: Write> Writer<'a, W> {
     /// **NOTE** This function is not guaranteed to perform any actual write, since it relies on
     /// internal buffering for performance reasons. If you want to be sure the value has been
     /// written, then call [`flush`](struct.Writer.html#method.flush).
-    pub fn append_ser<S: Serialize>(&mut self, value: S) -> Result<usize, AvroError> {
+    pub fn append_ser<S: Serialize>(&mut self, value: S) -> AvroResult<usize> {
         let avro_value = value.serialize(&mut self.serializer)?;
         self.append(avro_value)
     }
@@ -138,7 +138,7 @@ impl<'a, W: Write> Writer<'a, W> {
     ///
     /// **NOTE** This function forces the written data to be flushed (an implicit
     /// call to [`flush`](struct.Writer.html#method.flush) is performed).
-    pub fn extend<I, T: Into<Value>>(&mut self, values: I) -> Result<usize, AvroError>
+    pub fn extend<I, T: Into<Value>>(&mut self, values: I) -> AvroResult<usize>
     where
         I: IntoIterator<Item = T>,
     {
@@ -173,7 +173,7 @@ impl<'a, W: Write> Writer<'a, W> {
     ///
     /// **NOTE** This function forces the written data to be flushed (an implicit
     /// call to [`flush`](struct.Writer.html#method.flush) is performed).
-    pub fn extend_ser<I, T: Serialize>(&mut self, values: I) -> Result<usize, AvroError>
+    pub fn extend_ser<I, T: Serialize>(&mut self, values: I) -> AvroResult<usize>
     where
         I: IntoIterator<Item = T>,
     {
@@ -207,7 +207,7 @@ impl<'a, W: Write> Writer<'a, W> {
     ///
     /// **NOTE** This function forces the written data to be flushed (an implicit
     /// call to [`flush`](struct.Writer.html#method.flush) is performed).
-    pub fn extend_from_slice(&mut self, values: &[Value]) -> Result<usize, AvroError> {
+    pub fn extend_from_slice(&mut self, values: &[Value]) -> AvroResult<usize> {
         let mut num_bytes = 0;
         for value in values {
             num_bytes += self.append_value_ref(value)?;
@@ -221,7 +221,7 @@ impl<'a, W: Write> Writer<'a, W> {
     /// has been written before releasing the `Writer`.
     ///
     /// Return the number of bytes written.
-    pub fn flush(&mut self) -> Result<usize, AvroError> {
+    pub fn flush(&mut self) -> AvroResult<usize> {
         if self.num_values == 0 {
             return Ok(0);
         }
@@ -246,30 +246,30 @@ impl<'a, W: Write> Writer<'a, W> {
     ///
     /// **NOTE** This function forces the written data to be flushed (an implicit
     /// call to [`flush`](struct.Writer.html#method.flush) is performed).
-    pub fn into_inner(mut self) -> Result<W, AvroError> {
+    pub fn into_inner(mut self) -> AvroResult<W> {
         self.flush()?;
         Ok(self.writer)
     }
 
     /// Generate and append synchronization marker to the payload.
-    fn append_marker(&mut self) -> Result<usize, AvroError> {
+    fn append_marker(&mut self) -> AvroResult<usize> {
         // using .writer.write directly to avoid mutable borrow of self
         // with ref borrowing of self.marker
         Ok(self.writer.write(&self.marker)?)
     }
 
     /// Append a raw Avro Value to the payload avoiding to encode it again.
-    fn append_raw(&mut self, value: &Value, schema: &Schema) -> Result<usize, AvroError> {
+    fn append_raw(&mut self, value: &Value, schema: &Schema) -> AvroResult<usize> {
         self.append_bytes(encode_to_vec(&value, schema).as_ref())
     }
 
     /// Append pure bytes to the payload.
-    fn append_bytes(&mut self, bytes: &[u8]) -> Result<usize, AvroError> {
+    fn append_bytes(&mut self, bytes: &[u8]) -> AvroResult<usize> {
         Ok(self.writer.write(bytes)?)
     }
 
     /// Create an Avro header based on schema, codec and sync marker.
-    fn header(&self) -> Result<Vec<u8>, AvroError> {
+    fn header(&self) -> AvroResult<Vec<u8>> {
         let schema_bytes = serde_json::to_string(self.schema)?.into_bytes();
 
         let mut metadata = HashMap::with_capacity(2);
@@ -298,22 +298,18 @@ fn write_avro_datum<T: Into<Value>>(
     schema: &Schema,
     value: T,
     buffer: &mut Vec<u8>,
-) -> Result<(), AvroError> {
+) -> AvroResult<()> {
     let avro = value.into();
     if !avro.validate(schema) {
-        return Err(AvroError::ValidationError(
-            "value does not match schema".to_string(),
-        ));
+        return Err(Error::Validation("value does not match schema".to_string()));
     }
     encode(&avro, schema, buffer);
     Ok(())
 }
 
-fn write_value_ref(schema: &Schema, value: &Value, buffer: &mut Vec<u8>) -> Result<(), AvroError> {
+fn write_value_ref(schema: &Schema, value: &Value, buffer: &mut Vec<u8>) -> AvroResult<()> {
     if !value.validate(schema) {
-        return Err(AvroError::ValidationError(
-            "value does not match schema".to_string(),
-        ));
+        return Err(Error::Validation("value does not match schema".to_string()));
     }
     encode_ref(value, schema, buffer);
     Ok(())
@@ -325,7 +321,7 @@ fn write_value_ref(schema: &Schema, value: &Value, buffer: &mut Vec<u8>) -> Resu
 /// **NOTE** This function has a quite small niche of usage and does NOT generate headers and sync
 /// markers; use [`Writer`](struct.Writer.html) to be fully Avro-compatible if you don't know what
 /// you are doing, instead.
-pub fn to_avro_datum<T: Into<Value>>(schema: &Schema, value: T) -> Result<Vec<u8>, AvroError> {
+pub fn to_avro_datum<T: Into<Value>>(schema: &Schema, value: T) -> AvroResult<Vec<u8>> {
     let mut buffer = Vec::new();
     write_avro_datum(schema, value, &mut buffer)?;
     Ok(buffer)

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -2,11 +2,11 @@
 use std::collections::HashMap;
 use std::io::Write;
 
-use failure::{Error, Fail};
 use rand::random;
 use serde::Serialize;
 
 use crate::encode::{encode, encode_ref, encode_to_vec};
+use crate::errors::AvroError;
 use crate::schema::Schema;
 use crate::ser::Serializer;
 use crate::types::Value;
@@ -14,20 +14,6 @@ use crate::Codec;
 
 const DEFAULT_BLOCK_SIZE: usize = 16000;
 const AVRO_OBJECT_HEADER: &[u8] = b"Obj\x01";
-
-/// Describes errors happened while validating Avro data.
-#[derive(Fail, Debug)]
-#[fail(display = "Validation error: {}", _0)]
-pub struct ValidationError(String);
-
-impl ValidationError {
-    pub fn new<S>(msg: S) -> ValidationError
-    where
-        S: Into<String>,
-    {
-        ValidationError(msg.into())
-    }
-}
 
 /// Main interface for writing Avro formatted values.
 #[derive(typed_builder::TypedBuilder)]
@@ -81,7 +67,7 @@ impl<'a, W: Write> Writer<'a, W> {
     /// **NOTE** This function is not guaranteed to perform any actual write, since it relies on
     /// internal buffering for performance reasons. If you want to be sure the value has been
     /// written, then call [`flush`](struct.Writer.html#method.flush).
-    pub fn append<T: Into<Value>>(&mut self, value: T) -> Result<usize, Error> {
+    pub fn append<T: Into<Value>>(&mut self, value: T) -> Result<usize, AvroError> {
         let n = if !self.has_header {
             let header = self.header()?;
             let n = self.append_bytes(header.as_ref())?;
@@ -110,7 +96,7 @@ impl<'a, W: Write> Writer<'a, W> {
     /// **NOTE** This function is not guaranteed to perform any actual write, since it relies on
     /// internal buffering for performance reasons. If you want to be sure the value has been
     /// written, then call [`flush`](struct.Writer.html#method.flush).
-    pub fn append_value_ref(&mut self, value: &Value) -> Result<usize, Error> {
+    pub fn append_value_ref(&mut self, value: &Value) -> Result<usize, AvroError> {
         let n = if !self.has_header {
             let header = self.header()?;
             let n = self.append_bytes(header.as_ref())?;
@@ -140,7 +126,7 @@ impl<'a, W: Write> Writer<'a, W> {
     /// **NOTE** This function is not guaranteed to perform any actual write, since it relies on
     /// internal buffering for performance reasons. If you want to be sure the value has been
     /// written, then call [`flush`](struct.Writer.html#method.flush).
-    pub fn append_ser<S: Serialize>(&mut self, value: S) -> Result<usize, Error> {
+    pub fn append_ser<S: Serialize>(&mut self, value: S) -> Result<usize, AvroError> {
         let avro_value = value.serialize(&mut self.serializer)?;
         self.append(avro_value)
     }
@@ -152,7 +138,7 @@ impl<'a, W: Write> Writer<'a, W> {
     ///
     /// **NOTE** This function forces the written data to be flushed (an implicit
     /// call to [`flush`](struct.Writer.html#method.flush) is performed).
-    pub fn extend<I, T: Into<Value>>(&mut self, values: I) -> Result<usize, Error>
+    pub fn extend<I, T: Into<Value>>(&mut self, values: I) -> Result<usize, AvroError>
     where
         I: IntoIterator<Item = T>,
     {
@@ -187,7 +173,7 @@ impl<'a, W: Write> Writer<'a, W> {
     ///
     /// **NOTE** This function forces the written data to be flushed (an implicit
     /// call to [`flush`](struct.Writer.html#method.flush) is performed).
-    pub fn extend_ser<I, T: Serialize>(&mut self, values: I) -> Result<usize, Error>
+    pub fn extend_ser<I, T: Serialize>(&mut self, values: I) -> Result<usize, AvroError>
     where
         I: IntoIterator<Item = T>,
     {
@@ -221,7 +207,7 @@ impl<'a, W: Write> Writer<'a, W> {
     ///
     /// **NOTE** This function forces the written data to be flushed (an implicit
     /// call to [`flush`](struct.Writer.html#method.flush) is performed).
-    pub fn extend_from_slice(&mut self, values: &[Value]) -> Result<usize, Error> {
+    pub fn extend_from_slice(&mut self, values: &[Value]) -> Result<usize, AvroError> {
         let mut num_bytes = 0;
         for value in values {
             num_bytes += self.append_value_ref(value)?;
@@ -235,7 +221,7 @@ impl<'a, W: Write> Writer<'a, W> {
     /// has been written before releasing the `Writer`.
     ///
     /// Return the number of bytes written.
-    pub fn flush(&mut self) -> Result<usize, Error> {
+    pub fn flush(&mut self) -> Result<usize, AvroError> {
         if self.num_values == 0 {
             return Ok(0);
         }
@@ -260,30 +246,30 @@ impl<'a, W: Write> Writer<'a, W> {
     ///
     /// **NOTE** This function forces the written data to be flushed (an implicit
     /// call to [`flush`](struct.Writer.html#method.flush) is performed).
-    pub fn into_inner(mut self) -> Result<W, Error> {
+    pub fn into_inner(mut self) -> Result<W, AvroError> {
         self.flush()?;
         Ok(self.writer)
     }
 
     /// Generate and append synchronization marker to the payload.
-    fn append_marker(&mut self) -> Result<usize, Error> {
+    fn append_marker(&mut self) -> Result<usize, AvroError> {
         // using .writer.write directly to avoid mutable borrow of self
         // with ref borrowing of self.marker
         Ok(self.writer.write(&self.marker)?)
     }
 
     /// Append a raw Avro Value to the payload avoiding to encode it again.
-    fn append_raw(&mut self, value: &Value, schema: &Schema) -> Result<usize, Error> {
+    fn append_raw(&mut self, value: &Value, schema: &Schema) -> Result<usize, AvroError> {
         self.append_bytes(encode_to_vec(&value, schema).as_ref())
     }
 
     /// Append pure bytes to the payload.
-    fn append_bytes(&mut self, bytes: &[u8]) -> Result<usize, Error> {
+    fn append_bytes(&mut self, bytes: &[u8]) -> Result<usize, AvroError> {
         Ok(self.writer.write(bytes)?)
     }
 
     /// Create an Avro header based on schema, codec and sync marker.
-    fn header(&self) -> Result<Vec<u8>, Error> {
+    fn header(&self) -> Result<Vec<u8>, AvroError> {
         let schema_bytes = serde_json::to_string(self.schema)?.into_bytes();
 
         let mut metadata = HashMap::with_capacity(2);
@@ -312,18 +298,22 @@ fn write_avro_datum<T: Into<Value>>(
     schema: &Schema,
     value: T,
     buffer: &mut Vec<u8>,
-) -> Result<(), Error> {
+) -> Result<(), AvroError> {
     let avro = value.into();
     if !avro.validate(schema) {
-        return Err(ValidationError::new("value does not match schema").into());
+        return Err(AvroError::ValidationError(
+            "value does not match schema".to_string(),
+        ));
     }
     encode(&avro, schema, buffer);
     Ok(())
 }
 
-fn write_value_ref(schema: &Schema, value: &Value, buffer: &mut Vec<u8>) -> Result<(), Error> {
+fn write_value_ref(schema: &Schema, value: &Value, buffer: &mut Vec<u8>) -> Result<(), AvroError> {
     if !value.validate(schema) {
-        return Err(ValidationError::new("value does not match schema").into());
+        return Err(AvroError::ValidationError(
+            "value does not match schema".to_string(),
+        ));
     }
     encode_ref(value, schema, buffer);
     Ok(())
@@ -335,7 +325,7 @@ fn write_value_ref(schema: &Schema, value: &Value, buffer: &mut Vec<u8>) -> Resu
 /// **NOTE** This function has a quite small niche of usage and does NOT generate headers and sync
 /// markers; use [`Writer`](struct.Writer.html) to be fully Avro-compatible if you don't know what
 /// you are doing, instead.
-pub fn to_avro_datum<T: Into<Value>>(schema: &Schema, value: T) -> Result<Vec<u8>, Error> {
+pub fn to_avro_datum<T: Into<Value>>(schema: &Schema, value: T) -> Result<Vec<u8>, AvroError> {
     let mut buffer = Vec::new();
     write_avro_datum(schema, value, &mut buffer)?;
     Ok(buffer)

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -1,7 +1,7 @@
 //! Port of https://github.com/apache/avro/blob/release-1.9.1/lang/py/test/test_io.py
 use std::io::Cursor;
 
-use avro_rs::{from_avro_datum, to_avro_datum, types::Value, AvroError, Schema};
+use avro_rs::{from_avro_datum, to_avro_datum, types::Value, Error, Schema};
 use lazy_static::lazy_static;
 
 lazy_static! {
@@ -218,7 +218,7 @@ fn test_no_default_value() -> Result<(), String> {
     );
     match decoded {
         Ok(_) => Err(String::from("Expected SchemaResolutionError, got Ok")),
-        Err(AvroError::SchemaResolutionError(_)) => Ok(()),
+        Err(Error::SchemaResolution(_)) => Ok(()),
         Err(ref e) => Err(format!("Expected SchemaResolutionError, got {}", e)),
     }
 }
@@ -303,7 +303,7 @@ fn test_type_exception() -> Result<(), String> {
     let encoded = to_avro_datum(&writer_schema, datum_to_write);
     match encoded {
         Ok(_) => Err(String::from("Expected ValidationError, got Ok")),
-        Err(AvroError::ValidationError(_)) => Ok(()),
+        Err(Error::Validation(_)) => Ok(()),
         Err(ref e) => Err(format!("Expected ValidationError, got {}", e)),
     }
 }

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -1,9 +1,7 @@
 //! Port of https://github.com/apache/avro/blob/release-1.9.1/lang/py/test/test_io.py
 use std::io::Cursor;
 
-use avro_rs::{
-    from_avro_datum, to_avro_datum, types::Value, Schema, SchemaResolutionError, ValidationError,
-};
+use avro_rs::{from_avro_datum, to_avro_datum, types::Value, AvroError, Schema};
 use lazy_static::lazy_static;
 
 lazy_static! {
@@ -220,10 +218,13 @@ fn test_no_default_value() -> Result<(), String> {
     );
     match decoded {
         Ok(_) => Err(String::from("Expected SchemaResolutionError, got Ok")),
-        Err(ref e) => match e.downcast_ref::<SchemaResolutionError>() {
-            Some(_) => Ok(()),
-            None => Err(format!("Expected SchemaResolutionError, got {}", e)),
-        },
+        Err(ref e) => {
+            if let AvroError::SchemaResolutionError(_) = e {
+                Ok(())
+            } else {
+                Err(format!("Expected SchemaResolutionError, got {}", e))
+            }
+        }
     }
 }
 
@@ -307,9 +308,12 @@ fn test_type_exception() -> Result<(), String> {
     let encoded = to_avro_datum(&writer_schema, datum_to_write);
     match encoded {
         Ok(_) => Err(String::from("Expected ValidationError, got Ok")),
-        Err(ref e) => match e.downcast_ref::<ValidationError>() {
-            Some(_) => Ok(()),
-            None => Err(format!("Expected ValidationError, got {}", e)),
-        },
+        Err(ref e) => {
+            if let AvroError::ValidationError(_) = e {
+                Ok(())
+            } else {
+                Err(format!("Expected ValidationError, got {}", e))
+            }
+        }
     }
 }

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -218,13 +218,8 @@ fn test_no_default_value() -> Result<(), String> {
     );
     match decoded {
         Ok(_) => Err(String::from("Expected SchemaResolutionError, got Ok")),
-        Err(ref e) => {
-            if let AvroError::SchemaResolutionError(_) = e {
-                Ok(())
-            } else {
-                Err(format!("Expected SchemaResolutionError, got {}", e))
-            }
-        }
+        Err(AvroError::SchemaResolutionError(_)) => Ok(()),
+        Err(ref e) => Err(format!("Expected SchemaResolutionError, got {}", e)),
     }
 }
 
@@ -308,12 +303,7 @@ fn test_type_exception() -> Result<(), String> {
     let encoded = to_avro_datum(&writer_schema, datum_to_write);
     match encoded {
         Ok(_) => Err(String::from("Expected ValidationError, got Ok")),
-        Err(ref e) => {
-            if let AvroError::ValidationError(_) = e {
-                Ok(())
-            } else {
-                Err(format!("Expected ValidationError, got {}", e))
-            }
-        }
+        Err(AvroError::ValidationError(_)) => Ok(()),
+        Err(ref e) => Err(format!("Expected ValidationError, got {}", e)),
     }
 }

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -730,7 +730,6 @@ fn test_root_error_is_not_swallowed_on_parse_error() -> Result<(), String> {
     let raw_schema = r#"/not/a/real/file"#;
     let error = Schema::parse_str(raw_schema).unwrap_err();
 
-    // TODO: (#82) this should be a ParseSchemaError wrapping the JSON error
     if let Error::JSON(e) = error {
         assert!(
             e.to_string().contains("expected value at line 1 column 1"),

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -1,6 +1,6 @@
 //! Port of https://github.com/apache/avro/blob/release-1.9.1/lang/py/test/test_schema.py
 use avro_rs::schema::Name;
-use avro_rs::AvroError;
+use avro_rs::Error;
 use avro_rs::Schema;
 use lazy_static::lazy_static;
 
@@ -731,7 +731,7 @@ fn test_root_error_is_not_swallowed_on_parse_error() -> Result<(), String> {
     let error = Schema::parse_str(raw_schema).unwrap_err();
 
     // TODO: (#82) this should be a ParseSchemaError wrapping the JSON error
-    if let AvroError::JSONError(e) = error {
+    if let Error::JSON(e) = error {
         assert!(
             e.to_string().contains("expected value at line 1 column 1"),
             e.to_string()

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -1,5 +1,6 @@
 //! Port of https://github.com/apache/avro/blob/release-1.9.1/lang/py/test/test_schema.py
 use avro_rs::schema::Name;
+use avro_rs::AvroError;
 use avro_rs::Schema;
 use lazy_static::lazy_static;
 
@@ -730,15 +731,17 @@ fn test_root_error_is_not_swallowed_on_parse_error() -> Result<(), String> {
     let error = Schema::parse_str(raw_schema).unwrap_err();
 
     // TODO: (#82) this should be a ParseSchemaError wrapping the JSON error
-    match error.downcast::<serde_json::error::Error>() {
-        Ok(e) => {
-            assert!(
-                e.to_string().contains("expected value at line 1 column 1"),
-                e.to_string()
-            );
-            Ok(())
-        }
-        Err(e) => Err(format!("Expected serde_json::error::Error, got {:?}", e)),
+    if let AvroError::JSONError(e) = error {
+        assert!(
+            e.to_string().contains("expected value at line 1 column 1"),
+            e.to_string()
+        );
+        Ok(())
+    } else {
+        Err(format!(
+            "Expected serde_json::error::Error, got {:?}",
+            error
+        ))
     }
 }
 


### PR DESCRIPTION
Closes #115

This is still a WIP branch, with lots of TODOs and some things about
thiserror I still can't wrap my head around. However, the heavy-lifting
is done, the failure crate has been removed from the list of
dependencies and compilation, tests, benchmarks and linting are all
green.

The two biggest things I have yet to figure out are:
1. How to deal with the errors manually defined in ser.rs and de.rs:
   they are publicly available and as soon as I touch anything I hit
   cryptic serde errors
2. How to make errors like TryFromIntError part of more abstract ones
   like ParseSchemaError, which could have a source error or just a
   String description.