### PR TITLE
Replace some manual from_str impls with strum

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,15 +1,13 @@
 //! Logic for all supported compression codecs in Avro.
-use std::io::{Read, Write};
-use std::str::FromStr;
-
+use crate::types::Value;
 use failure::Error;
 use libflate::deflate::{Decoder, Encoder};
-
-use crate::types::Value;
-use crate::util::DecodeError;
+use std::io::{Read, Write};
+use strum_macros::{EnumString, IntoStaticStr};
 
 /// The compression codec used to compress blocks.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, EnumString, IntoStaticStr)]
+#[strum(serialize_all = "kebab_case")]
 pub enum Codec {
     /// The `Null` codec simply passes through data uncompressed.
     Null,
@@ -26,30 +24,7 @@ pub enum Codec {
 
 impl From<Codec> for Value {
     fn from(value: Codec) -> Self {
-        Self::Bytes(
-            match value {
-                Codec::Null => "null",
-                Codec::Deflate => "deflate",
-                #[cfg(feature = "snappy")]
-                Codec::Snappy => "snappy",
-            }
-            .to_owned()
-            .into_bytes(),
-        )
-    }
-}
-
-impl FromStr for Codec {
-    type Err = DecodeError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "null" => Ok(Codec::Null),
-            "deflate" => Ok(Codec::Deflate),
-            #[cfg(feature = "snappy")]
-            "snappy" => Ok(Codec::Snappy),
-            _ => Err(DecodeError::new("unrecognized codec")),
-        }
+        Self::Bytes(<&str>::from(value).as_bytes().to_vec())
     }
 }
 
@@ -94,6 +69,7 @@ impl Codec {
             }
             #[cfg(feature = "snappy")]
             Codec::Snappy => {
+                use crate::util::DecodeError;
                 use byteorder::ByteOrder;
 
                 let decompressed_size = snap::decompress_len(&stream[..stream.len() - 4])?;
@@ -154,5 +130,27 @@ mod tests {
         assert!(INPUT.len() > stream.len());
         codec.decompress(&mut stream).unwrap();
         assert_eq!(INPUT, stream.as_slice());
+    }
+
+    #[test]
+    fn codec_to_str() {
+        assert_eq!(<&str>::from(Codec::Null), "null");
+        assert_eq!(<&str>::from(Codec::Deflate), "deflate");
+
+        #[cfg(feature = "snappy")]
+        assert_eq!(<&str>::from(Codec::Snappy), "snappy");
+    }
+
+    #[test]
+    fn codec_from_str() {
+        use std::str::FromStr;
+
+        assert_eq!(Codec::from_str("null").unwrap(), Codec::Null);
+        assert_eq!(Codec::from_str("deflate").unwrap(), Codec::Deflate);
+
+        #[cfg(feature = "snappy")]
+        assert_eq!(Codec::from_str("snappy").unwrap(), Codec::Snappy);
+
+        assert!(Codec::from_str("not a codec").is_err());
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -287,6 +287,7 @@ pub struct RecordField {
 
 /// Represents any valid order for a `field` in a `record` Avro schema.
 #[derive(Clone, Debug, PartialEq, EnumString)]
+#[strum(serialize_all = "kebab_case")]
 pub enum RecordFieldOrder {
     Ascending,
     Descending,
@@ -1205,5 +1206,24 @@ mod tests {
             schema,
             Schema::Union(UnionSchema::new(vec![Schema::Null, Schema::TimestampMicros]).unwrap())
         );
+    }
+
+    #[test]
+    fn record_field_order_from_str() {
+        use std::str::FromStr;
+
+        assert_eq!(
+            RecordFieldOrder::from_str("ascending").unwrap(),
+            RecordFieldOrder::Ascending
+        );
+        assert_eq!(
+            RecordFieldOrder::from_str("descending").unwrap(),
+            RecordFieldOrder::Descending
+        );
+        assert_eq!(
+            RecordFieldOrder::from_str("ignore").unwrap(),
+            RecordFieldOrder::Ignore
+        );
+        assert!(RecordFieldOrder::from_str("not an ordering").is_err());
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -12,6 +12,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt;
+use std::str::FromStr;
 use strum_macros::EnumString;
 
 /// Describes errors happened while parsing Avro schemas.
@@ -297,8 +298,6 @@ pub enum RecordFieldOrder {
 impl RecordField {
     /// Parse a `serde_json::Value` into a `RecordField`.
     fn parse(field: &Map<String, Value>, position: usize) -> Result<Self, Error> {
-        use std::str::FromStr;
-
         let name = field
             .name()
             .ok_or_else(|| ParseSchemaError::new("No `name` in record field"))?;


### PR DESCRIPTION
This PR replaces some manual `from_str` implementations with a derive of `strum_macros::EnumString`.