### PR TITLE
Deprecate ToAvro in favor of From<T> for Value impls

### DIFF
--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use avro_rs::{
     schema::Schema,
-    types::{Record, ToAvro, Value},
+    types::{Record, Value},
     Reader, Writer,
 };
 
@@ -127,7 +127,7 @@ fn make_small_record() -> (Schema, Value) {
     let small_record = {
         let mut small_record = Record::new(&small_schema).unwrap();
         small_record.put("field", "foo");
-        small_record.avro()
+        small_record.into()
     };
     (small_schema, small_record)
 }
@@ -149,7 +149,7 @@ fn make_big_record() -> (Schema, Value) {
         big_record.put("phone", "000000000");
         big_record.put("housenum", "0000");
         big_record.put("address", address);
-        big_record.avro()
+        big_record.into()
     };
 
     (big_schema, big_record)

--- a/benches/single.rs
+++ b/benches/single.rs
@@ -3,7 +3,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use avro_rs::{
     schema::Schema,
     to_avro_datum,
-    types::{Record, ToAvro, Value},
+    types::{Record, Value},
 };
 
 const RAW_SMALL_SCHEMA: &str = r#"
@@ -126,7 +126,7 @@ fn make_small_record() -> (Schema, Value) {
     let small_record = {
         let mut small_record = Record::new(&small_schema).unwrap();
         small_record.put("field", "foo");
-        small_record.avro()
+        small_record.into()
     };
 
     (small_schema, small_record)
@@ -149,7 +149,7 @@ fn make_big_record() -> (Schema, Value) {
         big_record.put("phone", "000000000");
         big_record.put("housenum", "0000");
         big_record.put("address", address);
-        big_record.avro()
+        big_record.into()
     };
 
     (big_schema, big_record)

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use avro_rs::{
     schema::Schema,
-    types::{Record, ToAvro, Value},
+    types::{Record, Value},
     Reader, Writer,
 };
 
@@ -90,7 +90,7 @@ fn main() {
 
     let mut small_record = Record::new(&small_schema).unwrap();
     small_record.put("field", "foo");
-    let small_record = small_record.avro();
+    let small_record = small_record.into();
 
     let raw_address_schema = r#"{"fields": [{"default": "NONE", "type": "string", "name": "street"}, {"default": "NONE", "type": "string", "name": "city"}, {"default": "NONE", "type": "string", "name": "state_prov"}, {"default": "NONE", "type": "string", "name": "country"}, {"default": "NONE", "type": "string", "name": "zip"}], "type": "record", "name": "mailing_address"}"#;
     let address_schema = Schema::parse_str(raw_address_schema).unwrap();
@@ -107,7 +107,7 @@ fn main() {
     big_record.put("phone", "000000000");
     big_record.put("housenum", "0000");
     big_record.put("address", address);
-    let big_record = big_record.avro();
+    let big_record = big_record.into();
 
     benchmark(&small_schema, &small_record, "S", 10_000, 1);
     benchmark(&big_schema, &big_record, "B", 10_000, 1);

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use failure::Error;
 use libflate::deflate::{Decoder, Encoder};
 
-use crate::types::{ToAvro, Value};
+use crate::types::Value;
 use crate::util::DecodeError;
 
 /// The compression codec used to compress blocks.
@@ -24,10 +24,10 @@ pub enum Codec {
     Snappy,
 }
 
-impl ToAvro for Codec {
-    fn avro(self) -> Value {
-        Value::Bytes(
-            match self {
+impl From<Codec> for Value {
+    fn from(value: Codec) -> Self {
+        Self::Bytes(
+            match value {
                 Codec::Null => "null",
                 Codec::Deflate => "deflate",
                 #[cfg(feature = "snappy")]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -295,7 +295,7 @@ pub fn from_avro_datum<R: Read>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{Record, ToAvro};
+    use crate::types::Record;
     use crate::Reader;
     use std::io::Cursor;
 
@@ -342,7 +342,7 @@ mod tests {
         let mut record = Record::new(&schema).unwrap();
         record.put("a", 27i64);
         record.put("b", "foo");
-        let expected = record.avro();
+        let expected = record.into();
 
         assert_eq!(
             from_avro_datum(&schema, &mut encoded, None).unwrap(),
@@ -374,7 +374,7 @@ mod tests {
         record2.put("a", 42i64);
         record2.put("b", "bar");
 
-        let expected = vec![record1.avro(), record2.avro()];
+        let expected = vec![record1.into(), record2.into()];
 
         for (i, value) in reader.enumerate() {
             assert_eq!(value.unwrap(), expected[i]);

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -9,7 +9,7 @@ use serde::{
     Serialize,
 };
 
-use crate::types::{ToAvro, Value};
+use crate::types::Value;
 
 #[derive(Clone, Default)]
 pub struct Serializer {}
@@ -195,7 +195,7 @@ impl<'b> ser::Serializer for &'b mut Serializer {
     }
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        Ok(ToAvro::avro(None::<Self::Ok>))
+        Ok(Value::from(None::<Self::Ok>))
     }
 
     fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
@@ -203,7 +203,7 @@ impl<'b> ser::Serializer for &'b mut Serializer {
         T: Serialize,
     {
         let v = value.serialize(&mut Serializer::default())?;
-        Ok(ToAvro::avro(Some(v)))
+        Ok(Value::from(Some(v)))
     }
 
     fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -102,7 +102,10 @@ pub enum Value {
 }
 /// Any structure implementing the [ToAvro](trait.ToAvro.html) trait will be usable
 /// from a [Writer](../writer/struct.Writer.html).
-#[deprecated(since = "0.11.0", note = "Please use Value::from instead")]
+#[deprecated(
+    since = "0.11.0",
+    note = "Please use Value::from, Into::into or value.into() instead"
+)]
 pub trait ToAvro {
     /// Transforms this value into an Avro-compatible [Value](enum.Value.html).
     fn avro(self) -> Value;

--- a/src/types.rs
+++ b/src/types.rs
@@ -125,7 +125,6 @@ macro_rules! to_value(
     );
 );
 
-to_value!((), |_| Value::Null);
 to_value!(bool, Value::Boolean);
 to_value!(i32, Value::Int);
 to_value!(i64, Value::Long);
@@ -136,6 +135,12 @@ to_value!(Vec<u8>, Value::Bytes);
 to_value!(uuid::Uuid, Value::Uuid);
 to_value!(Decimal, Value::Decimal);
 to_value!(Duration, Value::Duration);
+
+impl From<()> for Value {
+    fn from(value: ()) -> Self {
+        Self::Null
+    }
+}
 
 impl From<usize> for Value {
     fn from(value: usize) -> Self {

--- a/src/types.rs
+++ b/src/types.rs
@@ -102,94 +102,83 @@ pub enum Value {
 }
 /// Any structure implementing the [ToAvro](trait.ToAvro.html) trait will be usable
 /// from a [Writer](../writer/struct.Writer.html).
+#[deprecated(since = "0.11.0", note = "Please use Value::from instead")]
 pub trait ToAvro {
     /// Transforms this value into an Avro-compatible [Value](enum.Value.html).
     fn avro(self) -> Value;
 }
 
-macro_rules! to_avro(
-    ($t:ty, $v:expr) => (
-        impl ToAvro for $t {
-            fn avro(self) -> Value {
-                $v(self)
+#[allow(deprecated)]
+impl<T: Into<Value>> ToAvro for T {
+    fn avro(self) -> Value {
+        self.into()
+    }
+}
+
+macro_rules! to_value(
+    ($type:ty, $variant_constructor:expr) => (
+        impl From<$type> for Value {
+            fn from(value: $type) -> Self {
+                $variant_constructor(value)
             }
         }
     );
 );
 
-to_avro!(bool, Value::Boolean);
-to_avro!(i32, Value::Int);
-to_avro!(i64, Value::Long);
-to_avro!(f32, Value::Float);
-to_avro!(f64, Value::Double);
-to_avro!(String, Value::String);
-to_avro!(Vec<u8>, Value::Bytes);
-to_avro!(uuid::Uuid, Value::Uuid);
-to_avro!(Decimal, Value::Decimal);
-to_avro!(Duration, Value::Duration);
+to_value!((), |_| Value::Null);
+to_value!(bool, Value::Boolean);
+to_value!(i32, Value::Int);
+to_value!(i64, Value::Long);
+to_value!(f32, Value::Float);
+to_value!(f64, Value::Double);
+to_value!(String, Value::String);
+to_value!(Vec<u8>, Value::Bytes);
+to_value!(uuid::Uuid, Value::Uuid);
+to_value!(Decimal, Value::Decimal);
+to_value!(Duration, Value::Duration);
 
-impl ToAvro for () {
-    fn avro(self) -> Value {
-        Value::Null
+impl From<usize> for Value {
+    fn from(value: usize) -> Self {
+        i64::try_from(value)
+            .expect("cannot convert usize to i64")
+            .into()
     }
 }
 
-impl ToAvro for usize {
-    fn avro(self) -> Value {
-        (self as i64).avro()
+impl From<&str> for Value {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_owned())
     }
 }
 
-impl<'a> ToAvro for &'a str {
-    fn avro(self) -> Value {
-        Value::String(self.to_owned())
+impl From<&[u8]> for Value {
+    fn from(value: &[u8]) -> Self {
+        Self::Bytes(value.to_owned())
     }
 }
 
-impl<'a> ToAvro for &'a [u8] {
-    fn avro(self) -> Value {
-        Value::Bytes(self.to_owned())
-    }
-}
-
-impl<T> ToAvro for Option<T>
+impl<T> From<Option<T>> for Value
 where
-    T: ToAvro,
+    T: Into<Self>,
 {
-    fn avro(self) -> Value {
-        Value::Union(Box::new(self.map_or_else(|| Value::Null, T::avro)))
+    fn from(value: Option<T>) -> Self {
+        Self::Union(Box::new(value.map_or_else(|| Self::Null, Into::into)))
     }
 }
 
-impl<T, S: BuildHasher> ToAvro for HashMap<String, T, S>
+impl<K, V, S> From<HashMap<K, V, S>> for Value
 where
-    T: ToAvro,
+    K: Into<String>,
+    V: Into<Self>,
+    S: BuildHasher,
 {
-    fn avro(self) -> Value {
-        Value::Map(
-            self.into_iter()
-                .map(|(key, value)| (key, value.avro()))
+    fn from(value: HashMap<K, V, S>) -> Self {
+        Self::Map(
+            value
+                .into_iter()
+                .map(|(key, value)| (key.into(), value.into()))
                 .collect(),
         )
-    }
-}
-
-impl<'a, T, S: BuildHasher> ToAvro for HashMap<&'a str, T, S>
-where
-    T: ToAvro,
-{
-    fn avro(self) -> Value {
-        Value::Map(
-            self.into_iter()
-                .map(|(key, value)| (key.to_owned(), value.avro()))
-                .collect::<_>(),
-        )
-    }
-}
-
-impl ToAvro for Value {
-    fn avro(self) -> Value {
-        self
     }
 }
 
@@ -235,37 +224,35 @@ impl<'a> Record<'a> {
     /// this `Record`. Does not perform any schema validation.
     pub fn put<V>(&mut self, field: &str, value: V)
     where
-        V: ToAvro,
+        V: Into<Value>,
     {
         if let Some(&position) = self.schema_lookup.get(field) {
-            self.fields[position].1 = value.avro()
+            self.fields[position].1 = value.into()
         }
     }
 }
 
-impl<'a> ToAvro for Record<'a> {
-    fn avro(self) -> Value {
-        Value::Record(self.fields)
+impl<'a> From<Record<'a>> for Value {
+    fn from(value: Record<'a>) -> Self {
+        Self::Record(value.fields)
     }
 }
 
-impl ToAvro for JsonValue {
-    fn avro(self) -> Value {
-        match self {
-            JsonValue::Null => Value::Null,
-            JsonValue::Bool(b) => Value::Boolean(b),
+impl From<JsonValue> for Value {
+    fn from(value: JsonValue) -> Self {
+        match value {
+            JsonValue::Null => Self::Null,
+            JsonValue::Bool(b) => b.into(),
             JsonValue::Number(ref n) if n.is_i64() => Value::Long(n.as_i64().unwrap()),
             JsonValue::Number(ref n) if n.is_f64() => Value::Double(n.as_f64().unwrap()),
             JsonValue::Number(n) => Value::Long(n.as_u64().unwrap() as i64), // TODO: Not so great
-            JsonValue::String(s) => Value::String(s),
-            JsonValue::Array(items) => {
-                Value::Array(items.into_iter().map(|item| item.avro()).collect::<_>())
-            }
+            JsonValue::String(s) => s.into(),
+            JsonValue::Array(items) => Value::Array(items.into_iter().map(Value::from).collect()),
             JsonValue::Object(items) => Value::Map(
                 items
                     .into_iter()
-                    .map(|(key, value)| (key, value.avro()))
-                    .collect::<_>(),
+                    .map(|(key, value)| (key, value.into()))
+                    .collect(),
             ),
         }
     }
@@ -739,7 +726,7 @@ impl Value {
                     None => match field.default {
                         Some(ref value) => match field.schema {
                             Schema::Enum { ref symbols, .. } => {
-                                value.clone().avro().resolve_enum(symbols)?
+                                Value::from(value.clone()).resolve_enum(symbols)?
                             }
                             Schema::Union(ref union_schema) => {
                                 let first = &union_schema.variants()[0];
@@ -747,12 +734,12 @@ impl Value {
                                 // backward-compatible schemas with many nullable fields
                                 match first {
                                     Schema::Null => Value::Union(Box::new(Value::Null)),
-                                    _ => {
-                                        Value::Union(Box::new(value.clone().avro().resolve(first)?))
-                                    }
+                                    _ => Value::Union(Box::new(
+                                        Value::from(value.clone()).resolve(first)?,
+                                    )),
                                 }
                             }
-                            _ => value.clone().avro(),
+                            _ => Value::from(value.clone()),
                         },
                         None => {
                             return Err(SchemaResolutionError::new(format!(

--- a/src/types.rs
+++ b/src/types.rs
@@ -137,7 +137,7 @@ to_value!(Decimal, Value::Decimal);
 to_value!(Duration, Value::Duration);
 
 impl From<()> for Value {
-    fn from(value: ()) -> Self {
+    fn from(_: ()) -> Self {
         Self::Null
     }
 }


### PR DESCRIPTION
This PR deprecates the `ToAvro` trait in favor of `From<T> for Value` implementations.

`ToAvro` is now implemented in terms of `From`, along with a deprecation warning to any code that uses it from the next release onward.