### PR TITLE
Add rustfmt.toml and consolidate imports

### DIFF
--- a/benches/serde.rs
+++ b/benches/serde.rs
@@ -1,11 +1,10 @@
-use criterion::{criterion_group, criterion_main, Criterion};
-use std::time::Duration;
-
 use avro_rs::{
     schema::Schema,
     types::{Record, Value},
     Reader, Writer,
 };
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::time::Duration;
 
 const RAW_SMALL_SCHEMA: &str = r#"
 {

--- a/benches/serde_json.rs
+++ b/benches/serde_json.rs
@@ -1,8 +1,6 @@
-use serde_json::Value;
-use std::collections::HashMap;
-use std::iter::FromIterator;
-
 use criterion::{criterion_group, criterion_main, Criterion};
+use serde_json::Value;
+use std::{collections::HashMap, iter::FromIterator};
 
 fn make_big_json_record() -> Value {
     let address = HashMap::<_, _>::from_iter(vec![

--- a/benches/single.rs
+++ b/benches/single.rs
@@ -1,10 +1,9 @@
-use criterion::{criterion_group, criterion_main, Criterion};
-
 use avro_rs::{
     schema::Schema,
     to_avro_datum,
     types::{Record, Value},
 };
+use criterion::{criterion_group, criterion_main, Criterion};
 
 const RAW_SMALL_SCHEMA: &str = r#"
 {

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -1,10 +1,9 @@
-use std::time::{Duration, Instant};
-
 use avro_rs::{
     schema::Schema,
     types::{Record, Value},
     Reader, Writer,
 };
+use std::time::{Duration, Instant};
 
 fn nanos(duration: Duration) -> u64 {
     duration.as_secs() * 1_000_000_000 + duration.subsec_nanos() as u64

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2018"
+merge_imports = true

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,6 +1,8 @@
 //! Logic for all supported compression codecs in Avro.
-use crate::errors::{AvroResult, Error};
-use crate::types::Value;
+use crate::{
+    errors::{AvroResult, Error},
+    types::Value,
+};
 use libflate::deflate::{Decoder, Encoder};
 use std::io::{Read, Write};
 use strum_macros::{EnumString, IntoStaticStr};

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,18 +1,17 @@
 //! Logic for serde-compatible deserialization.
-use std::collections::{
-    hash_map::{Keys, Values},
-    HashMap,
-};
-use std::fmt;
-use std::slice::Iter;
-
+use crate::{errors::Error, types::Value};
 use serde::{
     de::{self, DeserializeSeed, Visitor},
     forward_to_deserialize_any, Deserialize,
 };
-
-use crate::errors::Error;
-use crate::types::Value;
+use std::{
+    collections::{
+        hash_map::{Keys, Values},
+        HashMap,
+    },
+    fmt,
+    slice::Iter,
+};
 
 impl de::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Self {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -1,15 +1,13 @@
-use std::collections::HashMap;
-use std::io::Read;
-use std::str::FromStr;
-
+use crate::{
+    decimal::Decimal,
+    duration::Duration,
+    errors::{AvroResult, Error},
+    schema::Schema,
+    types::Value,
+    util::{safe_len, zag_i32, zag_i64},
+};
+use std::{collections::HashMap, io::Read, str::FromStr};
 use uuid::Uuid;
-
-use crate::decimal::Decimal;
-use crate::duration::Duration;
-use crate::errors::{AvroResult, Error};
-use crate::schema::Schema;
-use crate::types::Value;
-use crate::util::{safe_len, zag_i32, zag_i64};
 
 #[inline]
 fn decode_long<R: Read>(reader: &mut R) -> AvroResult<Value> {

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1,6 +1,8 @@
-use crate::schema::Schema;
-use crate::types::Value;
-use crate::util::{zig_i32, zig_i64};
+use crate::{
+    schema::Schema,
+    types::Value,
+    util::{zig_i32, zig_i64},
+};
 use std::convert::TryInto;
 
 /// Encode a `Value` into avro format.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -693,23 +693,26 @@ pub mod schema;
 pub mod schema_compatibility;
 pub mod types;
 
-pub use crate::codec::Codec;
-pub use crate::de::from_value;
-pub use crate::decimal::Decimal;
-pub use crate::duration::{Days, Duration, Millis, Months};
-pub use crate::errors::Error;
-pub use crate::reader::{from_avro_datum, Reader};
-pub use crate::schema::Schema;
-pub use crate::ser::to_value;
-pub use crate::util::max_allocation_bytes;
-pub use crate::writer::{to_avro_datum, Writer};
+pub use crate::{
+    codec::Codec,
+    de::from_value,
+    decimal::Decimal,
+    duration::{Days, Duration, Millis, Months},
+    errors::Error,
+    reader::{from_avro_datum, Reader},
+    schema::Schema,
+    ser::to_value,
+    util::max_allocation_bytes,
+    writer::{to_avro_datum, Writer},
+};
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::reader::Reader;
-    use crate::schema::Schema;
-    use crate::types::{Record, Value};
+    use crate::{
+        from_avro_datum,
+        types::{Record, Value},
+        Codec, Reader, Schema, Writer,
+    };
 
     //TODO: move where it fits better
     #[test]

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,15 +1,16 @@
 //! Logic handling reading from Avro format at user level.
-use std::io::{ErrorKind, Read};
-use std::str::{from_utf8, FromStr};
-
+use crate::{
+    decode::decode,
+    errors::{AvroResult, Error},
+    schema::Schema,
+    types::Value,
+    util, Codec,
+};
 use serde_json::from_slice;
-
-use crate::decode::decode;
-use crate::errors::{AvroResult, Error};
-use crate::schema::Schema;
-use crate::types::Value;
-use crate::util;
-use crate::Codec;
+use std::{
+    io::{ErrorKind, Read},
+    str::{from_utf8, FromStr},
+};
 
 // Internal Block reader.
 #[derive(Debug, Clone)]
@@ -296,8 +297,7 @@ pub fn from_avro_datum<R: Read>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::Record;
-    use crate::Reader;
+    use crate::{types::Record, Reader};
     use std::io::Cursor;
 
     const SCHEMA: &str = r#"

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,18 +1,16 @@
 //! Logic for parsing and interacting with schemas in Avro format.
-use crate::errors::{AvroResult, Error};
-use crate::types;
-use crate::util::MapHelper;
+use crate::{
+    errors::{AvroResult, Error},
+    types,
+    util::MapHelper,
+};
 use digest::Digest;
 use serde::{
     ser::{SerializeMap, SerializeSeq},
     Deserialize, Serialize, Serializer,
 };
 use serde_json::{Map, Value};
-use std::borrow::Cow;
-use std::collections::HashMap;
-use std::convert::TryInto;
-use std::fmt;
-use std::str::FromStr;
+use std::{borrow::Cow, collections::HashMap, convert::TryInto, fmt, str::FromStr};
 use strum_macros::EnumString;
 
 /// Represents an Avro schema fingerprint

--- a/src/schema_compatibility.rs
+++ b/src/schema_compatibility.rs
@@ -1,10 +1,10 @@
 //! Logic for checking schema compatibility
-use std::collections::hash_map::DefaultHasher;
-use std::collections::HashSet;
-use std::hash::Hasher;
-use std::ptr;
-
 use crate::schema::{Schema, SchemaKind};
+use std::{
+    collections::{hash_map::DefaultHasher, HashSet},
+    hash::Hasher,
+    ptr,
+};
 
 pub struct SchemaCompatibility;
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,13 +1,7 @@
 //! Logic for serde-compatible serialization.
-use std::collections::HashMap;
-use std::fmt;
-use std::iter::once;
-
+use crate::{errors::Error, types::Value};
 use serde::{ser, Serialize};
-
-use crate::errors::Error;
-use crate::types::Value;
-
+use std::{collections::HashMap, fmt, iter::once};
 impl ser::Error for Error {
     fn custom<T: fmt::Display>(msg: T) -> Self {
         Error::Ser(msg.to_string())

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,17 +1,13 @@
 //! Logic handling the intermediate representation of Avro values.
-use std::collections::HashMap;
-use std::convert::TryFrom;
-use std::hash::BuildHasher;
-use std::str::FromStr;
-use std::u8;
-
+use crate::{
+    decimal::Decimal,
+    duration::Duration,
+    errors::{AvroResult, Error},
+    schema::{Precision, RecordField, Scale, Schema, SchemaKind, UnionSchema},
+};
 use serde_json::Value as JsonValue;
+use std::{collections::HashMap, convert::TryFrom, hash::BuildHasher, str::FromStr, u8};
 use uuid::Uuid;
-
-use crate::decimal::Decimal;
-use crate::duration::Duration;
-use crate::errors::{AvroResult, Error};
-use crate::schema::{Precision, RecordField, Scale, Schema, SchemaKind, UnionSchema};
 
 /// Compute the maximum decimal value precision of a byte array of length `len` could hold.
 fn max_prec_for_len(len: usize) -> Result<usize, std::num::TryFromIntError> {
@@ -766,10 +762,12 @@ impl Value {
 
 #[cfg(test)]
 mod tests {
-    use crate::decimal::Decimal;
-    use crate::duration::{Days, Duration, Millis, Months};
-    use crate::schema::{Name, RecordField, RecordFieldOrder, Schema, UnionSchema};
-    use crate::types::Value;
+    use crate::{
+        decimal::Decimal,
+        duration::{Days, Duration, Millis, Months},
+        schema::{Name, RecordField, RecordFieldOrder, Schema, UnionSchema},
+        types::Value,
+    };
     use uuid::Uuid;
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,6 @@
-use std::i64;
-use std::io::Read;
-use std::sync::Once;
-
-use serde_json::{Map, Value};
-
 use crate::errors::{AvroResult, Error};
+use serde_json::{Map, Value};
+use std::{i64, io::Read, sync::Once};
 
 /// Maximum number of bytes that can be allocated when decoding
 /// Avro-encoded values. This is a protection against ill-formed

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,16 +1,15 @@
 //! Logic handling writing in Avro format at user level.
-use std::collections::HashMap;
-use std::io::Write;
-
+use crate::{
+    encode::{encode, encode_ref, encode_to_vec},
+    errors::{AvroResult, Error},
+    schema::Schema,
+    ser::Serializer,
+    types::Value,
+    Codec,
+};
 use rand::random;
 use serde::Serialize;
-
-use crate::encode::{encode, encode_ref, encode_to_vec};
-use crate::errors::{AvroResult, Error};
-use crate::schema::Schema;
-use crate::ser::Serializer;
-use crate::types::Value;
-use crate::Codec;
+use std::{collections::HashMap, io::Write};
 
 const DEFAULT_BLOCK_SIZE: usize = 16000;
 const AVRO_OBJECT_HEADER: &[u8] = b"Obj\x01";
@@ -330,11 +329,13 @@ pub fn to_avro_datum<T: Into<Value>>(schema: &Schema, value: T) -> AvroResult<Ve
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::decimal::Decimal;
-    use crate::duration::{Days, Duration, Millis, Months};
-    use crate::schema::Name;
-    use crate::types::Record;
-    use crate::util::zig_i64;
+    use crate::{
+        decimal::Decimal,
+        duration::{Days, Duration, Millis, Months},
+        schema::Name,
+        types::Record,
+        util::zig_i64,
+    };
     use serde::{Deserialize, Serialize};
 
     const AVRO_OBJECT_HEADER_LEN: usize = AVRO_OBJECT_HEADER.len();

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -1,8 +1,7 @@
 //! Port of https://github.com/apache/avro/blob/release-1.9.1/lang/py/test/test_io.py
-use std::io::Cursor;
-
 use avro_rs::{from_avro_datum, to_avro_datum, types::Value, Error, Schema};
 use lazy_static::lazy_static;
+use std::io::Cursor;
 
 lazy_static! {
     static ref SCHEMAS_TO_VALIDATE: Vec<(&'static str, Value)> = vec![

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -1,7 +1,5 @@
 //! Port of https://github.com/apache/avro/blob/release-1.9.1/lang/py/test/test_schema.py
-use avro_rs::schema::Name;
-use avro_rs::Error;
-use avro_rs::Schema;
+use avro_rs::{schema::Name, Error, Schema};
 use lazy_static::lazy_static;
 
 lazy_static! {


### PR DESCRIPTION
This PR adds `rustfmt.toml` with two settings (and applies the config to the repo):

- `edition = "2018"` -- this is needed for running `rustfmt` on language features that are 2018 only, such as `async`/`await`
  while we don't have any `async`/`await` specifically, `avro-rs` _is_ a 2018 edition crate so we should have a rustfmt.toml consistent with that
- `merge_imports = true` -- this is a style preference