### PR TITLE
Bump rand crate to 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ crc = { version = "1.3.0", optional = true }
 digest = "0.9"
 libflate = "1"
 num-bigint = "0.2.6"
-rand = "0.4"
+rand = "0.7.0"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 snap = { version = "0.2.3", optional = true }


### PR DESCRIPTION
By update [rand](https://crates.io/crates/rand) crate this PR fix advisory [RUSTSEC-2019-0035](https://rustsec.org/advisories/RUSTSEC-2019-0035).

Before:
```
$ cargo-deny check advisories
2020-12-16 20:20:41 [WARN] unable to find a config path, falling back to default config
warning[A004]: Unaligned memory access
   ┌─ /home/kirill/projects/avro-rs/Cargo.lock:59:1
   │
59 │ rand_core 0.3.1 registry+https://github.com/rust-lang/crates.io-index
   │ --------------------------------------------------------------------- unsound advisory detected
   │
   = ID: RUSTSEC-2019-0035
   = Advisory: https://rustsec.org/advisories/RUSTSEC-2019-0035
   = Affected versions of this crate violated alignment when casting byte slices to
     integer slices, resulting in undefined behavior.
     
     The flaw was corrected by Ralf Jung and Diggory Hardy.
   = Announcement: https://github.com/rust-random/rand/blob/master/rand_core/CHANGELOG.md#050---2019-06-06
   = Solution: Upgrade to >=0.4.2
   = rand_core v0.3.1
     ├── rand v0.4.6
     │   └── avro-rs v0.12.0
     └── rdrand v0.4.0
         └── rand v0.4.6 (*)

advisories ok
```
After:
```
 cargo-deny check advisories
2020-12-16 20:20:36 [WARN] unable to find a config path, falling back to default config
advisories ok
```