### PR TITLE
allow Value::Bytes to be assigned to Schema::Fixed ...

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -68,7 +68,11 @@ pub fn encode_ref(value: &Value, schema: &Schema, buffer: &mut Vec<u8>) {
             buffer.extend_from_slice(&slice);
         }
         Value::Uuid(uuid) => encode_bytes(&uuid.to_string(), buffer),
-        Value::Bytes(bytes) => encode_bytes(bytes, buffer),
+        Value::Bytes(bytes) => match *schema {
+            Schema::Bytes => encode_bytes(bytes, buffer),
+            Schema::Fixed{..} => buffer.extend(bytes),
+            _ => (),
+        },
         Value::String(s) => match *schema {
             Schema::String => {
                 encode_bytes(s, buffer);

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -70,7 +70,7 @@ pub fn encode_ref(value: &Value, schema: &Schema, buffer: &mut Vec<u8>) {
         Value::Uuid(uuid) => encode_bytes(&uuid.to_string(), buffer),
         Value::Bytes(bytes) => match *schema {
             Schema::Bytes => encode_bytes(bytes, buffer),
-            Schema::Fixed{..} => buffer.extend(bytes),
+            Schema::Fixed { .. } => buffer.extend(bytes),
             _ => (),
         },
         Value::String(s) => match *schema {

--- a/src/types.rs
+++ b/src/types.rs
@@ -331,6 +331,7 @@ impl Value {
             (&Value::String(_), &Schema::String) => true,
             (&Value::String(_), &Schema::Uuid) => true,
             (&Value::Fixed(n, _), &Schema::Fixed { size, .. }) => n == size,
+            (&Value::Bytes(ref b), &Schema::Fixed { size, .. }) => b.len() == size,
             (&Value::Fixed(n, _), &Schema::Duration) => n == 12,
             // TODO: check precision against n
             (&Value::Fixed(_n, _), &Schema::Decimal { .. }) => true,
@@ -811,6 +812,8 @@ mod tests {
 
         assert!(Value::Fixed(4, vec![0, 0, 0, 0]).validate(&schema));
         assert!(!Value::Fixed(5, vec![0, 0, 0, 0, 0]).validate(&schema));
+        assert!(Value::Bytes(vec![0, 0, 0, 0]).validate(&schema));
+        assert!(!Value::Bytes(vec![0, 0, 0, 0, 0]).validate(&schema));
     }
 
     #[test]


### PR DESCRIPTION
... as long as the length matches. This seems needed to enable Serde and serde-bytes to provide Fixed values.