### PR TITLE
Remove unnecessary cast (clippy warning)

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 /// Compute the maximum decimal value precision of a byte array of length `len` could hold.
 fn max_prec_for_len(len: usize) -> Result<usize, Error> {
     let len = i32::try_from(len).map_err(|e| Error::ConvertLengthToI32(e, len))?;
-    Ok((2.0_f64.powi(8 * len - 1) - 1.0 as f64).log10().floor() as usize)
+    Ok((2.0_f64.powi(8 * len - 1) - 1.0).log10().floor() as usize)
 }
 
 /// A valid Avro value.


### PR DESCRIPTION
With the upgrade to Rust 1.49, the clippy lint `unnecessary_cast` was
[enhanced to work with integer and float literals][0]. There is one
instance of this in the code base that is breaking the build.

This change removes the cast and fixes the clippy warning.

[0]: https://github.com/rust-lang/rust-clippy/blob/00586dfdcd10c37cb8b132c72ed0558304955042/CHANGELOG.md#enhancements-1