### PR TITLE
Support for parsing a list of schemas which may have cross dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,38 @@ let schema = Schema::parse_str(raw_schema).unwrap();
 println!("{:?}", schema);
 ```
 
+Additionally, a list of of definitions (which may depend on each other) can be given and all of
+them will be parsed into the corresponding schemas.
+
+```rust
+use avro_rs::Schema;
+
+let raw_schema_1 = r#"{
+        "name": "A",
+        "type": "record",
+        "fields": [
+            {"name": "field_one", "type": "float"}
+        ]
+    }"#;
+
+// This definition depends on the definition of A above
+let raw_schema_2 = r#"{
+        "name": "B",
+        "type": "record",
+        "fields": [
+            {"name": "field_one", "type": "A"}
+        ]
+    }"#;
+
+// if the schemas are not valid, this function will return an error
+let schemas = Schema::parse_list(&[raw_schema_1, raw_schema_2]).unwrap();
+
+// schemas can be printed for debugging
+println!("{:?}", schemas);
+```
+*N.B.* It is important to note that the composition of schema definitions requires schemas with names.
+For this reason, only schemas of type Record, Enum, and Fixed should be input into this function.
+
 The library provides also a programmatic interface to define schemas without encoding them in
 JSON (for advanced use), but we highly recommend the JSON interface. Please read the API
 reference in case you are interested.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 use crate::{schema::SchemaKind, types::ValueKind};
 use std::fmt;
+use crate::types::Value;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -17,6 +18,9 @@ pub enum Error {
 
     #[error("Not a string value, required for uuid: {0:?}")]
     GetUuidFromStringValue(ValueKind),
+
+    #[error("Two schemas with the same fullname were given: {0:?}")]
+    NameCollision(String),
 
     #[error("Not a fixed or bytes type, required for decimal schema, got: {0:?}")]
     ResolveDecimalSchema(SchemaKind),

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,5 @@
 use crate::{schema::SchemaKind, types::ValueKind};
 use std::fmt;
-use crate::types::Value;
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,38 @@
 //! println!("{:?}", schema);
 //! ```
 //!
+//! Additionally, a list of of definitions (which may depend on each other) can be given and all of
+//! them will be parsed into the corresponding schemas.
+//!
+//! ```
+//! use avro_rs::Schema;
+//!
+//! let raw_schema_1 = r#"{
+//!         "name": "A",
+//!         "type": "record",
+//!         "fields": [
+//!             {"name": "field_one", "type": "float"}
+//!         ]
+//!     }"#;
+//!
+//! // This definition depends on the definition of A above
+//! let raw_schema_2 = r#"{
+//!         "name": "B",
+//!         "type": "record",
+//!         "fields": [
+//!             {"name": "field_one", "type": "A"}
+//!         ]
+//!     }"#;
+//!
+//! // if the schemas are not valid, this function will return an error
+//! let schemas = Schema::parse_list(&[raw_schema_1, raw_schema_2]).unwrap();
+//!
+//! // schemas can be printed for debugging
+//! println!("{:?}", schemas);
+//! ```
+//! *N.B.* It is important to note that the composition of schema definitions requires schemas with names.
+//! For this reason, only schemas of type Record, Enum, and Fixed should be input into this function.
+//!
 //! The library provides also a programmatic interface to define schemas without encoding them in
 //! JSON (for advanced use), but we highly recommend the JSON interface. Please read the API
 //! reference in case you are interested.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -509,7 +509,7 @@ impl Parser {
         let value = self
             .input_schemas
             .remove(name)
-            .ok_or(Error::ParsePrimitive(name.into()))?;
+            .ok_or_else(|| Error::ParsePrimitive(name.into()))?;
         let parsed = self.parse(&value)?;
         self.parsed_schemas.insert(name.to_string(), parsed.clone());
         Ok(parsed)

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -453,7 +453,8 @@ impl Parser {
     /// the schemas have cross-dependencies; these will be resolved during parsing.
     fn parse_list(&mut self) -> Result<Vec<Schema>, Error> {
         while !self.input_schemas.is_empty() {
-            let next_name = self.input_schemas
+            let next_name = self
+                .input_schemas
                 .keys()
                 .next()
                 .expect("Input schemas unexpectedly empty")
@@ -505,7 +506,7 @@ impl Parser {
         if let Some(parsed) = self.parsed_schemas.get(name) {
             return Ok(parsed.clone());
         }
-        let value= self
+        let value = self
             .input_schemas
             .remove(name)
             .ok_or(Error::ParsePrimitive(name.into()))?;

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -275,11 +275,11 @@ pub enum RecordFieldOrder {
 
 impl RecordField {
     /// Parse a `serde_json::Value` into a `RecordField`.
-    fn parse(field: &Map<String, Value>, position: usize) -> AvroResult<Self> {
+    fn parse(field: &Map<String, Value>, position: usize, parser: &mut Parser) -> AvroResult<Self> {
         let name = field.name().ok_or(Error::GetNameFieldFromRecord)?;
 
         // TODO: "type" = "<record name>"
-        let schema = Schema::parse_complex(field)?;
+        let schema = parser.parse_complex(field)?;
 
         let default = field.get("default").cloned();
 
@@ -378,25 +378,13 @@ fn parse_json_integer_for_decimal(value: &serde_json::Number) -> Result<DecimalM
     })
 }
 
+#[derive(Default)]
+struct Parser {
+    input_schemas: HashMap<String, Value>,
+    parsed_schemas: HashMap<String, Schema>
+}
+
 impl Schema {
-    /// Create a `Schema` from a string representing a JSON Avro schema.
-    pub fn parse_str(input: &str) -> Result<Self, Error> {
-        // TODO: (#82) this should be a ParseSchemaError wrapping the JSON error
-        let value = serde_json::from_str(input).map_err(Error::ParseSchemaJson)?;
-        Self::parse(&value)
-    }
-
-    /// Create a `Schema` from a `serde_json::Value` representing a JSON Avro
-    /// schema.
-    pub fn parse(value: &Value) -> AvroResult<Self> {
-        match *value {
-            Value::String(ref t) => Schema::parse_primitive(t.as_str()),
-            Value::Object(ref data) => Schema::parse_complex(data),
-            Value::Array(ref data) => Schema::parse_union(data),
-            _ => Err(Error::ParseSchemaFromValidJson),
-        }
-    }
-
     /// Converts `self` into its [Parsing Canonical Form].
     ///
     /// [Parsing Canonical Form]:
@@ -421,10 +409,85 @@ impl Schema {
         }
     }
 
-    /// Parse a `serde_json::Value` representing a primitive Avro type into a
-    /// `Schema`.
-    fn parse_primitive(primitive: &str) -> AvroResult<Self> {
-        match primitive {
+    /// Create a `Schema` from a string representing a JSON Avro schema.
+    pub fn parse_str(input: &str) -> Result<Schema, Error> {
+        let mut parser = Parser::default();
+        parser.parse_str(input)
+    }
+
+    /// Create a array of `Schema`'s from a list of JSON Avro schemas. It is allowed that
+    /// the schemas have cross-dependencies; these will be resolved during parsing.
+    pub fn parse_list(input: &[&str]) -> Result<Vec<Schema>, Error>{
+        let mut input_schemas: HashMap<String, Value> = HashMap::with_capacity(input.len());
+        for js in input {
+            let schema: Value = serde_json::from_str(js).map_err(Error::ParseSchemaJson)?;
+            if let Value::Object(inner) = &schema {
+                let fullname = Name::parse(&inner)?.fullname(None);
+                let _ = input_schemas.insert(fullname, schema);
+            } else {
+                return Err(Error::GetNameField);
+            }
+        }
+        let mut parser = Parser {
+            input_schemas,
+            parsed_schemas: HashMap::with_capacity(input.len())
+        };
+        parser.parse_list()
+    }
+
+    pub fn parse(value: &Value) -> AvroResult<Schema> {
+        let mut parser = Parser::default();
+        parser.parse(value)
+    }
+}
+
+impl Parser {
+
+    /// Create a `Schema` from a string representing a JSON Avro schema.
+    fn parse_str(&mut self, input: &str) -> Result<Schema, Error> {
+        // TODO: (#82) this should be a ParseSchemaError wrapping the JSON error
+        let value = serde_json::from_str(input).map_err(Error::ParseSchemaJson)?;
+        self.parse(&value)
+    }
+
+    /// Create a array of `Schema`'s from a an iterator of JSON Avro schemas. It is allowed that
+    /// the schemas have cross-dependencies; these will be resolved during parsing.
+    fn parse_list(&mut self) -> Result<Vec<Schema>, Error> {
+
+        while !self.input_schemas.is_empty() {
+            let next_name = self.input_schemas.keys().next()
+                .expect("Input schemas unexpectedly empty")
+                .to_owned();
+            let (name, value) = self.input_schemas.remove_entry(&next_name)
+                .expect("Key unexpectedly missing");
+            let parsed = self.parse(&value)?;
+            self.parsed_schemas.insert(name, parsed);
+        }
+
+        let mut parsed_schemas = Vec::new();
+        for (_, parsed) in self.parsed_schemas.drain() {
+            parsed_schemas.push(parsed);
+        }
+        Ok(parsed_schemas)
+
+    }
+
+    /// Create a `Schema` from a `serde_json::Value` representing a JSON Avro
+    /// schema.
+    fn parse(&mut self, value: &Value) -> AvroResult<Schema> {
+        match *value {
+            Value::String(ref t) => self.parse_known_schema(t.as_str()),
+            Value::Object(ref data) => self.parse_complex(data),
+            Value::Array(ref data) => self.parse_union(data),
+            _ => Err(Error::ParseSchemaFromValidJson),
+        }
+    }
+
+    /// Parse a `serde_json::Value` representing an Avro type whose Schema is known into a
+    /// `Schema`. A Schema for a `serde_json::Value` is known if it is primitive or has
+    /// been parsed previously by the parsed and stored in its map of parsed_schemas.
+    fn parse_known_schema(&mut self, name: &str) -> AvroResult<Schema> {
+        match name {
             "null" => Ok(Schema::Null),
             "boolean" => Ok(Schema::Boolean),
             "int" => Ok(Schema::Int),
@@ -433,8 +496,19 @@ impl Schema {
             "float" => Ok(Schema::Float),
             "bytes" => Ok(Schema::Bytes),
             "string" => Ok(Schema::String),
-            other => Err(Error::ParsePrimitive(other.into())),
+            _ => self.fetch_schema(name),
         }
+    }
+
+    fn fetch_schema(&mut self, name: &str) -> AvroResult<Schema> {
+        if let Some(parsed) = self.parsed_schemas.get(name) {
+            return Ok(parsed.clone());
+        }
+        let value= self.input_schemas.remove(name)
+            .ok_or(Error::ParsePrimitive(name.into()))?;
+        let parsed = self.parse(&value)?;
+        self.parsed_schemas.insert(name.to_string(), parsed.clone());
+        Ok(parsed)
     }
 
     fn parse_precision_and_scale(
@@ -463,14 +537,15 @@ impl Schema {
     ///
     /// Avro supports "recursive" definition of types.
     /// e.g: {"type": {"type": "string"}}
-    fn parse_complex(complex: &Map<String, Value>) -> AvroResult<Self> {
+    fn parse_complex(&mut self, complex: &Map<String, Value>) -> AvroResult<Schema> {
         fn logical_verify_type(
             complex: &Map<String, Value>,
             kinds: &[SchemaKind],
+            parser: &mut Parser
         ) -> AvroResult<Schema> {
             match complex.get("type") {
                 Some(value) => {
-                    let ty = Schema::parse(value)?;
+                    let ty = parser.parse(value)?;
                     if kinds
                         .iter()
                         .any(|&kind| SchemaKind::from(ty.clone()) == kind)
@@ -489,6 +564,7 @@ impl Schema {
                     let inner = Box::new(logical_verify_type(
                         complex,
                         &[SchemaKind::Fixed, SchemaKind::Bytes],
+                        self
                     )?);
 
                     let (precision, scale) = Self::parse_precision_and_scale(complex)?;
@@ -500,31 +576,31 @@ impl Schema {
                     });
                 }
                 "uuid" => {
-                    logical_verify_type(complex, &[SchemaKind::String])?;
+                    logical_verify_type(complex, &[SchemaKind::String],self)?;
                     return Ok(Schema::Uuid);
                 }
                 "date" => {
-                    logical_verify_type(complex, &[SchemaKind::Int])?;
+                    logical_verify_type(complex, &[SchemaKind::Int], self)?;
                     return Ok(Schema::Date);
                 }
                 "time-millis" => {
-                    logical_verify_type(complex, &[SchemaKind::Int])?;
+                    logical_verify_type(complex, &[SchemaKind::Int], self)?;
                     return Ok(Schema::TimeMillis);
                 }
                 "time-micros" => {
-                    logical_verify_type(complex, &[SchemaKind::Long])?;
+                    logical_verify_type(complex, &[SchemaKind::Long], self)?;
                     return Ok(Schema::TimeMicros);
                 }
                 "timestamp-millis" => {
-                    logical_verify_type(complex, &[SchemaKind::Long])?;
+                    logical_verify_type(complex, &[SchemaKind::Long], self)?;
                     return Ok(Schema::TimestampMillis);
                 }
                 "timestamp-micros" => {
-                    logical_verify_type(complex, &[SchemaKind::Long])?;
+                    logical_verify_type(complex, &[SchemaKind::Long], self)?;
                     return Ok(Schema::TimestampMicros);
                 }
                 "duration" => {
-                    logical_verify_type(complex, &[SchemaKind::Fixed])?;
+                    logical_verify_type(complex, &[SchemaKind::Fixed], self)?;
                     return Ok(Schema::Duration);
                 }
                 // In this case, of an unknown logical type, we just pass through to the underlying
@@ -539,15 +615,15 @@ impl Schema {
         }
         match complex.get("type") {
             Some(&Value::String(ref t)) => match t.as_str() {
-                "record" => Schema::parse_record(complex),
-                "enum" => Schema::parse_enum(complex),
-                "array" => Schema::parse_array(complex),
-                "map" => Schema::parse_map(complex),
-                "fixed" => Schema::parse_fixed(complex),
-                other => Schema::parse_primitive(other),
+                "record" => self.parse_record(complex),
+                "enum" => Self::parse_enum(complex),
+                "array" => self.parse_array(complex),
+                "map" => self.parse_map(complex),
+                "fixed" => Self::parse_fixed(complex),
+                other => self.parse_known_schema(other),
             },
-            Some(&Value::Object(ref data)) => Schema::parse_complex(data),
-            Some(&Value::Array(ref variants)) => Schema::parse_union(variants),
+            Some(&Value::Object(ref data)) => self.parse_complex(data),
+            Some(&Value::Array(ref variants)) => self.parse_union(variants),
             Some(unknown) => Err(Error::GetComplexType(unknown.clone())),
             None => Err(Error::GetComplexTypeField),
         }
@@ -555,7 +631,7 @@ impl Schema {
 
     /// Parse a `serde_json::Value` representing a Avro record type into a
     /// `Schema`.
-    fn parse_record(complex: &Map<String, Value>) -> AvroResult<Self> {
+    fn parse_record(&mut self, complex: &Map<String, Value>) -> AvroResult<Schema> {
         let name = Name::parse(complex)?;
 
         let mut lookup = HashMap::new();
@@ -569,7 +645,7 @@ impl Schema {
                     .iter()
                     .filter_map(|field| field.as_object())
                     .enumerate()
-                    .map(|(position, field)| RecordField::parse(field, position))
+                    .map(|(position, field)| RecordField::parse(field, position, self))
                     .collect::<Result<_, _>>()
             })?;
 
@@ -587,7 +663,7 @@ impl Schema {
 
     /// Parse a `serde_json::Value` representing a Avro enum type into a
     /// `Schema`.
-    fn parse_enum(complex: &Map<String, Value>) -> AvroResult<Self> {
+    fn parse_enum(complex: &Map<String, Value>) -> AvroResult<Schema> {
         let name = Name::parse(complex)?;
 
         let symbols = complex
@@ -611,37 +687,37 @@ impl Schema {
 
     /// Parse a `serde_json::Value` representing a Avro array type into a
     /// `Schema`.
-    fn parse_array(complex: &Map<String, Value>) -> AvroResult<Self> {
+    fn parse_array(&mut self, complex: &Map<String, Value>) -> AvroResult<Schema> {
         complex
             .get("items")
             .ok_or(Error::GetArrayItemsField)
-            .and_then(|items| Schema::parse(items))
+            .and_then(|items| self.parse(items))
             .map(|schema| Schema::Array(Box::new(schema)))
     }
 
     /// Parse a `serde_json::Value` representing a Avro map type into a
     /// `Schema`.
-    fn parse_map(complex: &Map<String, Value>) -> AvroResult<Self> {
+    fn parse_map(&mut self, complex: &Map<String, Value>) -> AvroResult<Schema> {
         complex
             .get("values")
             .ok_or(Error::GetMapValuesField)
-            .and_then(|items| Schema::parse(items))
+            .and_then(|items| self.parse(items))
             .map(|schema| Schema::Map(Box::new(schema)))
     }
 
     /// Parse a `serde_json::Value` representing a Avro union type into a
     /// `Schema`.
-    fn parse_union(items: &[Value]) -> AvroResult<Self> {
+    fn parse_union(&mut self, items: &[Value]) -> AvroResult<Schema> {
         items
             .iter()
-            .map(Schema::parse)
+            .map(|v| self.parse(v))
             .collect::<Result<Vec<_>, _>>()
             .and_then(|schemas| Ok(Schema::Union(UnionSchema::new(schemas)?)))
     }
 
     /// Parse a `serde_json::Value` representing a Avro fixed type into a
     /// `Schema`.
-    fn parse_fixed(complex: &Map<String, Value>) -> AvroResult<Self> {
+    fn parse_fixed(complex: &Map<String, Value>) -> AvroResult<Schema> {
         let name = Name::parse(complex)?;
 
         let size = complex

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -381,7 +381,7 @@ fn parse_json_integer_for_decimal(value: &serde_json::Number) -> Result<DecimalM
 #[derive(Default)]
 struct Parser {
     input_schemas: HashMap<String, Value>,
-    parsed_schemas: HashMap<String, Schema>
+    parsed_schemas: HashMap<String, Schema>,
 }
 
 impl Schema {
@@ -417,7 +417,7 @@ impl Schema {
 
     /// Create a array of `Schema`'s from a list of JSON Avro schemas. It is allowed that
     /// the schemas have cross-dependencies; these will be resolved during parsing.
-    pub fn parse_list(input: &[&str]) -> Result<Vec<Schema>, Error>{
+    pub fn parse_list(input: &[&str]) -> Result<Vec<Schema>, Error> {
         let mut input_schemas: HashMap<String, Value> = HashMap::with_capacity(input.len());
         for js in input {
             let schema: Value = serde_json::from_str(js).map_err(Error::ParseSchemaJson)?;
@@ -430,7 +430,7 @@ impl Schema {
         }
         let mut parser = Parser {
             input_schemas,
-            parsed_schemas: HashMap::with_capacity(input.len())
+            parsed_schemas: HashMap::with_capacity(input.len()),
         };
         parser.parse_list()
     }
@@ -442,7 +442,6 @@ impl Schema {
 }
 
 impl Parser {
-
     /// Create a `Schema` from a string representing a JSON Avro schema.
     fn parse_str(&mut self, input: &str) -> Result<Schema, Error> {
         // TODO: (#82) this should be a ParseSchemaError wrapping the JSON error
@@ -453,12 +452,15 @@ impl Parser {
     /// Create a array of `Schema`'s from a an iterator of JSON Avro schemas. It is allowed that
     /// the schemas have cross-dependencies; these will be resolved during parsing.
     fn parse_list(&mut self) -> Result<Vec<Schema>, Error> {
-
         while !self.input_schemas.is_empty() {
-            let next_name = self.input_schemas.keys().next()
+            let next_name = self.input_schemas
+                .keys()
+                .next()
                 .expect("Input schemas unexpectedly empty")
                 .to_owned();
-            let (name, value) = self.input_schemas.remove_entry(&next_name)
+            let (name, value) = self
+                .input_schemas
+                .remove_entry(&next_name)
                 .expect("Key unexpectedly missing");
             let parsed = self.parse(&value)?;
             self.parsed_schemas.insert(name, parsed);
@@ -469,7 +471,6 @@ impl Parser {
             parsed_schemas.push(parsed);
         }
         Ok(parsed_schemas)
-
     }
 
     /// Create a `Schema` from a `serde_json::Value` representing a JSON Avro
@@ -504,7 +505,9 @@ impl Parser {
         if let Some(parsed) = self.parsed_schemas.get(name) {
             return Ok(parsed.clone());
         }
-        let value= self.input_schemas.remove(name)
+        let value= self
+            .input_schemas
+            .remove(name)
             .ok_or(Error::ParsePrimitive(name.into()))?;
         let parsed = self.parse(&value)?;
         self.parsed_schemas.insert(name.to_string(), parsed.clone());
@@ -541,7 +544,7 @@ impl Parser {
         fn logical_verify_type(
             complex: &Map<String, Value>,
             kinds: &[SchemaKind],
-            parser: &mut Parser
+            parser: &mut Parser,
         ) -> AvroResult<Schema> {
             match complex.get("type") {
                 Some(value) => {
@@ -564,7 +567,7 @@ impl Parser {
                     let inner = Box::new(logical_verify_type(
                         complex,
                         &[SchemaKind::Fixed, SchemaKind::Bytes],
-                        self
+                        self,
                     )?);
 
                     let (precision, scale) = Self::parse_precision_and_scale(complex)?;
@@ -576,7 +579,7 @@ impl Parser {
                     });
                 }
                 "uuid" => {
-                    logical_verify_type(complex, &[SchemaKind::String],self)?;
+                    logical_verify_type(complex, &[SchemaKind::String], self)?;
                     return Ok(Schema::Uuid);
                 }
                 "date" => {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -432,7 +432,7 @@ impl Schema {
                 let fullname = Name::parse(&inner)?.fullname(None);
                 let previous_value = input_schemas.insert(fullname.clone(), schema);
                 if previous_value.is_some() {
-                    return Err(Error::NameCollision(fullname))
+                    return Err(Error::NameCollision(fullname));
                 }
                 let _ = input_order.push(fullname);
             } else {
@@ -481,7 +481,9 @@ impl Parser {
 
         let mut parsed_schemas = Vec::with_capacity(self.parsed_schemas.len());
         for name in self.input_order.drain(0..) {
-            let parsed = self.parsed_schemas.remove(&name)
+            let parsed = self
+                .parsed_schemas
+                .remove(&name)
                 .expect("One of the input schemas was unexpectedly not parsed");
             parsed_schemas.push(parsed);
         }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -434,7 +434,7 @@ impl Schema {
                 if previous_value.is_some() {
                     return Err(Error::NameCollision(fullname));
                 }
-                let _ = input_order.push(fullname);
+                input_order.push(fullname);
             } else {
                 return Err(Error::GetNameField);
             }

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -690,7 +690,6 @@ fn test_parse_list_with_cross_deps_basic() {
     let schemas_first = Schema::parse_list(&schema_strs_first).expect("Test failed");
     let schemas_second = Schema::parse_list(&schema_strs_second).expect("Test failed");
 
-
     let parsed_1 = Schema::parse_str(&schema_str_1).expect("Test failed");
     let parsed_2 = Schema::parse_str(&schema_composite).expect("Test failed");
     assert_eq!(schemas_first, vec!(parsed_1.clone(), parsed_2.clone()));
@@ -735,7 +734,6 @@ fn test_parse_list_with_cross_deps_and_namespaces() {
     let schema_strs_second = [schema_str_2, schema_str_1];
     let schemas_first = Schema::parse_list(&schema_strs_first).expect("Test failed");
     let schemas_second = Schema::parse_list(&schema_strs_second).expect("Test failed");
-
 
     let parsed_1 = Schema::parse_str(&schema_str_1).expect("Test failed");
     let parsed_2 = Schema::parse_str(&schema_composite).expect("Test failed");

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -715,22 +715,6 @@ fn test_parse_list_recursive_type_error() {
             {"name": "field_one", "type": "A"}
         ]
     }"#;
-    let schema_composite = r#"{
-        "name": "B",
-        "type": "record",
-        "fields": [
-            { "name": "field_one",
-            "type": {
-                "name": "A",
-                "type": "record",
-                "fields": [
-                    {"name": "field_one", "type": "float"}
-                    ]
-                }
-            }
-        ]
-
-    }"#;
     let schema_strs_first = [schema_str_1, schema_str_2];
     let schema_strs_second = [schema_str_2, schema_str_1];
     let _ = Schema::parse_list(&schema_strs_first).expect_err("Test failed");

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -963,7 +963,31 @@ fn test_name_collision_error() {
     }"#;
 
     let _ = Schema::parse_list(&[schema_str_1, schema_str_2]).expect_err("Test failed");
+}
 
+#[test]
+/// Test that having the same name but different fullnames does not return an error
+fn test_namespace_prevents_collisions() {
+    let schema_str_1 = r#"{
+        "name": "A",
+        "type": "record",
+        "fields": [
+            {"name": "field_one", "type": "double"}
+        ]
+    }"#;
+    let schema_str_2 = r#"{
+        "name": "A",
+        "type": "record",
+        "namespace": "foo",
+        "fields": [
+            {"name": "field_two", "type": "string"}
+        ]
+    }"#;
+
+    let parsed = Schema::parse_list(&[schema_str_1, schema_str_2]).expect("Test failed");
+    let parsed_1 = Schema::parse_str(&schema_str_1).expect("Test failed");
+    let parsed_2 = Schema::parse_str(&schema_str_2).expect("Test failed");
+    assert_eq!(parsed, vec!(parsed_1, parsed_2));
 }
 
 // The fullname is determined in one of the following ways:

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -790,7 +790,7 @@ fn permutation_indices(indices: Vec<usize>) -> Vec<Vec<usize>> {
         }
     }
 
-    return perms
+    perms
 }
 
 #[test]
@@ -900,11 +900,11 @@ fn test_parse_list_shared_dependency() {
             ]
         }
     }"#;
-    
+
     let parsed = vec![
         Schema::parse_str(schema_str_3).expect("Test failed"),
         Schema::parse_str(schema_composite_1).expect("Test failed"),
-        Schema::parse_str(schema_composite_2).expect("Test failed")
+        Schema::parse_str(schema_composite_2).expect("Test failed"),
     ];
     let schema_strs = vec![schema_str_1, schema_str_2, schema_str_3];
     for schema_str_perm in permutations(&schema_strs) {

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -691,7 +691,6 @@ fn test_parse_list_with_cross_deps_basic() {
     }
 }
 
-
 #[test]
 /// Test that schema composition resolves namespaces.
 fn test_parse_list_with_cross_deps_and_namespaces() {
@@ -773,7 +772,7 @@ fn permutations<T>(list: &[T]) -> Vec<Vec<&T>> {
 }
 
 /// Return all permutations of the indices of a vector
-fn permutation_indices<'a>(indices: Vec<usize>) -> Vec<Vec<usize>>{
+fn permutation_indices(indices: Vec<usize>) -> Vec<Vec<usize>> {
     let size = indices.len();
     let mut perms: Vec<Vec<usize>> = Vec::new();
     if size == 1 {
@@ -789,8 +788,8 @@ fn permutation_indices<'a>(indices: Vec<usize>) -> Vec<Vec<usize>>{
             sub_index.insert(0, first[0]);
             perms.push(sub_index);
         }
-
     }
+
     return perms
 }
 
@@ -841,12 +840,13 @@ fn test_parse_list_multiple_dependencies() {
             }
         ]
     }"#;
-    let parsed = vec!(
+
+    let parsed = vec![
         Schema::parse_str(schema_str_2).expect("Test failed"),
         Schema::parse_str(schema_str_3).expect("Test failed"),
         Schema::parse_str(schema_composite).expect("Test failed")
-    );
-    let schema_strs = vec!(schema_str_1, schema_str_2, schema_str_3);
+    ];
+    let schema_strs = vec![schema_str_1, schema_str_2, schema_str_3];
     for schema_str_perm in permutations(&schema_strs) {
         let schema_str_perm: Vec<&str> = schema_str_perm.iter().map(|s| **s).collect();
         let schemas = Schema::parse_list(&schema_str_perm).expect("Test failed");
@@ -900,12 +900,13 @@ fn test_parse_list_shared_dependency() {
             ]
         }
     }"#;
-    let parsed = vec!(
+    
+    let parsed = vec![
         Schema::parse_str(schema_str_3).expect("Test failed"),
         Schema::parse_str(schema_composite_1).expect("Test failed"),
         Schema::parse_str(schema_composite_2).expect("Test failed")
-    );
-    let schema_strs = vec!(schema_str_1, schema_str_2, schema_str_3);
+    ];
+    let schema_strs = vec![schema_str_1, schema_str_2, schema_str_3];
     for schema_str_perm in permutations(&schema_strs) {
         let schema_str_perm: Vec<&str> = schema_str_perm.iter().map(|s| **s).collect();
         let schemas = Schema::parse_list(&schema_str_perm).expect("Test failed");
@@ -915,8 +916,6 @@ fn test_parse_list_shared_dependency() {
         }
     }
 }
-
-
 
 // The fullname is determined in one of the following ways:
 //  * A name and namespace are both specified.  For example,

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -844,7 +844,7 @@ fn test_parse_list_multiple_dependencies() {
     let parsed = vec![
         Schema::parse_str(schema_str_2).expect("Test failed"),
         Schema::parse_str(schema_str_3).expect("Test failed"),
-        Schema::parse_str(schema_composite).expect("Test failed")
+        Schema::parse_str(schema_composite).expect("Test failed"),
     ];
     let schema_strs = vec![schema_str_1, schema_str_2, schema_str_3];
     for schema_str_perm in permutations(&schema_strs) {


### PR DESCRIPTION
The current library only allows the parsing of jsons that are completely specified in their definitions, i.e. it is not possible to specify two types, one of which depends on the other, and be able to parse this without first composing the jsons.

For example, there is currently no way to parse the following situation "out of the box"
```json
{
 "name": "A",
 "type": "array",
 "items": "B"
},
{
  "name": "B",
  "type": "map",
  "values": "double"
}
```

 This means that in real life, one must work with very deeply nested json strings which can be very unwieldy. Additionally, many users would naturally like to specify lots of types with cross dependencies on each other but do not want to do lots of json manipulation to be able to parse their types. 
 
 This also affect libraries downstream. I attempted a fix for this with r[sgen-avro](https://github.com/lerouxrgd/rsgen-avro) since I wanted this feature for code generation (necessary for my work). However, large amounts of logic necessary to do this replicated logic already present in this repository. Thus I agreed with the maintainer that this feature more naturally belonged here. 

This adds a new parsing function `Schema::parse_list` which takes a list of json strings, which is allowed to have cross dependencies. An internal data structure `Parser` is created which does all the parsing and also maintains a map of parsed types to draw from as necessary. This data structure is dropped after parsing is finished so that the statelessness of the Schema type is maintained.

In the added tests, concrete examples can be found.