### PR TITLE
Validate enum symbols

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ digest = "0.9"
 libflate = "1"
 num-bigint = "0.2.6"
 rand = "0.7.0"
+regex = "^1.4"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 snap = { version = "0.2.3", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -256,6 +256,12 @@ pub enum Error {
     #[error("Unable to parse `symbols` in enum")]
     GetEnumSymbols,
 
+    #[error("Invalid enum symbol name {0}")]
+    EnumSymbolName(String),
+
+    #[error("Duplicate enum symbol {0}")]
+    EnumSymbolDuplicate(String),
+
     #[error("No `items` in array")]
     GetArrayItemsField,
 


### PR DESCRIPTION
Ensure that symbol names are valid ([A-Za-z_][A-Za-z0-9_]*) and unique
within an enum.

Fixes #179