### PR TITLE
add new codec: Zstandard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 
 [features]
 snappy = ["crc", "snap"]
+zstandard = ["zstd"]
 
 [lib]
 path = "src/lib.rs"
@@ -46,6 +47,7 @@ typed-builder = "0.5.1"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 zerocopy = "0.3.0"
 lazy_static = "^1.1"
+zstd = { version = "0.6.1+zstd.1.4.9" , optional = true }
 
 [dev-dependencies]
 md-5 = "0.9"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ version = "x.y"
 features = ["snappy"]
 ```
 
+Or in case you want to leverage the **Zstandard** codec:
+
+```toml
+[dependencies.avro-rs]
+version = "x.y"
+features = ["zstandard"]
+```
+
 ## Upgrading to a newer minor version
 
 The library is still in beta, so there might be backward-incompatible changes between minor
@@ -225,6 +233,8 @@ RFC 1950) does not have a checksum.
 * **Snappy**: uses Google's [Snappy](http://google.github.io/snappy/) compression library. Each
 compressed block is followed by the 4-byte, big-endianCRC32 checksum of the uncompressed data in
 the block. You must enable the `snappy` feature to use this codec.
+* **Zstandard**: uses Facebook's [Zstandard](https://facebook.github.io/zstd/) compression library.
+You must enable the `zstandard` feature to use this codec.
 
 To specify a codec to use to compress data, just specify it while creating a `Writer`:
 ```rust

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -19,6 +19,8 @@ pub enum Codec {
     /// compression library. Each compressed block is followed by the 4-byte, big-endian
     /// CRC32 checksum of the uncompressed data in the block.
     Snappy,
+    #[cfg(feature = "zstandard")]
+    Zstd,
 }
 
 impl From<Codec> for Value {
@@ -56,6 +58,12 @@ impl Codec {
 
                 *stream = encoded;
             }
+            #[cfg(feature = "zstandard")]
+            Codec::Zstd => {
+                let mut encoder = zstd::Encoder::new(Vec::new(), 0).unwrap();
+                encoder.write_all(stream).map_err(Error::ZstdCompress)?;
+                *stream = encoder.finish().unwrap();
+            }
         };
 
         Ok(())
@@ -90,6 +98,13 @@ impl Codec {
                 if expected != actual {
                     return Err(Error::SnappyCrc32 { expected, actual });
                 }
+                decoded
+            }
+            #[cfg(feature = "zstandard")]
+            Codec::Zstd => {
+                let mut decoded = Vec::new();
+                let mut decoder = zstd::Decoder::new(&stream[..]).unwrap();
+                std::io::copy(&mut decoder, &mut decoded).map_err(Error::ZstdDecompress)?;
                 decoded
             }
         };
@@ -136,6 +151,18 @@ mod tests {
         assert_eq!(INPUT, stream.as_slice());
     }
 
+    #[cfg(feature = "zstandard")]
+    #[test]
+    fn zstd_compress_and_decompress() {
+        let codec = Codec::Zstd;
+        let mut stream = INPUT.to_vec();
+        codec.compress(&mut stream).unwrap();
+        assert_ne!(INPUT, stream.as_slice());
+        assert!(INPUT.len() > stream.len());
+        codec.decompress(&mut stream).unwrap();
+        assert_eq!(INPUT, stream.as_slice());
+    }
+
     #[test]
     fn codec_to_str() {
         assert_eq!(<&str>::from(Codec::Null), "null");
@@ -143,6 +170,9 @@ mod tests {
 
         #[cfg(feature = "snappy")]
         assert_eq!(<&str>::from(Codec::Snappy), "snappy");
+
+        #[cfg(feature = "zstandard")]
+        assert_eq!(<&str>::from(Codec::Zstd), "zstd");
     }
 
     #[test]
@@ -154,6 +184,9 @@ mod tests {
 
         #[cfg(feature = "snappy")]
         assert_eq!(Codec::from_str("snappy").unwrap(), Codec::Snappy);
+
+        #[cfg(feature = "zstandard")]
+        assert_eq!(Codec::from_str("zstd").unwrap(), Codec::Zstd);
 
         assert!(Codec::from_str("not a codec").is_err());
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -292,6 +292,12 @@ pub enum Error {
     #[error("Failed to decompress with snappy")]
     SnappyDecompress(#[source] snap::Error),
 
+    #[error("Failed to compress with zstd")]
+    ZstdCompress(#[source] std::io::Error),
+
+    #[error("Failed to decompress with zstd")]
+    ZstdDecompress(#[source] std::io::Error),
+
     #[error("Failed to read header")]
     ReadHeader(#[source] std::io::Error),
 


### PR DESCRIPTION
Companies like CloudFlare use Zstandard instead of Snappy with Kafka: https://blog.cloudflare.com/squeezing-the-firehose/