### PR TITLE
Fix encoding of Uuid's that come from Serde

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -82,6 +82,9 @@ pub fn encode_ref(value: &Value, schema: &Schema, buffer: &mut Vec<u8>) {
                     encode_int(index as i32, buffer);
                 }
             }
+            Schema::Uuid => {
+                encode_bytes(s, buffer);
+            }
             _ => (),
         },
         Value::Fixed(_, bytes) => buffer.extend(bytes),


### PR DESCRIPTION
- Uuid are converted to Value::String by default, instead of Value::Uuid

Not sure if there is another way to complete this, I am relatively new to Rust so don't quite understand if we can tame Serde somehow to convert to Value::Uuid.